### PR TITLE
Check blend function source, destination and equation values

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can even specify textures already in Minecraft's resources!
 
 ## Use
 
-Documentation on the json format for skyboxes can be found [here](https://github.com/AMereBagatelle/fabricskyboxes/tree/1.17.x-dev/docs).
+Documentation on the json format for skyboxes can be found [here](docs).
 
 ##### Disclaimer:  Does not support Optifine skybox resource packs.  This is not planned.
 

--- a/docs/blend.md
+++ b/docs/blend.md
@@ -1,0 +1,68 @@
+# Blend Mode
+The mod uses `glBlendFunc(sourceFactor, destinationFactor)` and `glBlendEquation(equation)` for the sky boxes.
+[[Online Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php)]
+
+Using the example below to achieve the burn blend effect.
+
+##### Burn Blend Mode
+```
+glBlendFunc(ZERO, ONE_MINUS_SRC_COLOR);
+glBlendEquation(ADD);
+```
+
+```json
+{
+  "sFactor": 0,
+  "dFactor": 769,
+  "equation": 32774
+}
+```
+
+
+
+### Source Factor
+| Parameter                  | Value |
+|----------------------------|-------|
+| `CONSTANT_ALPHA`           | 32771 |
+| `CONSTANT_COLOR`           | 32769 |
+| `DST_ALPHA`                | 772   |
+| `DST_COLOR`                | 774   |
+| `ONE`                      | 1     |
+| `ONE_MINUS_CONSTANT_ALPHA` | 32772 |
+| `ONE_MINUS_CONSTANT_COLOR` | 32770 |
+| `ONE_MINUS_DST_ALPHA`      | 773   |
+| `ONE_MINUS_DST_COLOR`      | 775   |
+| `ONE_MINUS_SRC_ALPHA`      | 771   |
+| `ONE_MINUS_SRC_COLOR`      | 769   |
+| `SRC_ALPHA`                | 770   |
+| `SRC_ALPHA_SATURATE`       | 776   |
+| `SRC_COLOR`                | 768   |
+| `ZERO`                     | 0     |
+
+### Destination Factor
+| Parameter                  | Value |
+|----------------------------|-------|
+| `CONSTANT_ALPHA`           | 32771 |
+| `CONSTANT_COLOR`           | 32769 |
+| `DST_ALPHA`                | 772   |
+| `DST_COLOR`                | 774   |
+| `ONE`                      | 1     |
+| `ONE_MINUS_CONSTANT_ALPHA` | 32772 |
+| `ONE_MINUS_CONSTANT_COLOR` | 32770 |
+| `ONE_MINUS_DST_ALPHA`      | 773   |
+| `ONE_MINUS_DST_COLOR`      | 775   |
+| `ONE_MINUS_SRC_ALPHA`      | 771   |
+| `ONE_MINUS_SRC_COLOR`      | 769   |
+| `SRC_ALPHA`                | 770   |
+| `SRC_COLOR`                | 768   |
+| `ZERO`                     | 0     |
+
+### Equation
+| Parameter          | Value |
+|--------------------|-------|
+| `ADD`              | 32774 |
+| `SUBTRACT`         | 32778 |
+| `REVERSE_SUBTRACT` | 32779 |
+| `MIN`              | 32775 |
+| `MAX`              | 32776 |
+

--- a/docs/blend.md
+++ b/docs/blend.md
@@ -1,5 +1,5 @@
 # Blend Mode
-The mod uses `glBlendFunc(sourceFactor, destinationFactor)` and `glBlendEquation(equation)` for the sky boxes.
+The mod uses `glBlendFunc(sourceFactor, destinationFactor)` and `glBlendEquation(equation)` to blend the textured sky boxes.
 [[Online Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php)]
 
 Using the example below to achieve the burn blend effect.
@@ -20,7 +20,7 @@ glBlendEquation(ADD);
 
 
 
-### Source Factor
+### Source/Destination Factor
 | Parameter                  | Value |
 |----------------------------|-------|
 | `CONSTANT_ALPHA`           | 32771 |
@@ -36,24 +36,6 @@ glBlendEquation(ADD);
 | `ONE_MINUS_SRC_COLOR`      | 769   |
 | `SRC_ALPHA`                | 770   |
 | `SRC_ALPHA_SATURATE`       | 776   |
-| `SRC_COLOR`                | 768   |
-| `ZERO`                     | 0     |
-
-### Destination Factor
-| Parameter                  | Value |
-|----------------------------|-------|
-| `CONSTANT_ALPHA`           | 32771 |
-| `CONSTANT_COLOR`           | 32769 |
-| `DST_ALPHA`                | 772   |
-| `DST_COLOR`                | 774   |
-| `ONE`                      | 1     |
-| `ONE_MINUS_CONSTANT_ALPHA` | 32772 |
-| `ONE_MINUS_CONSTANT_COLOR` | 32770 |
-| `ONE_MINUS_DST_ALPHA`      | 773   |
-| `ONE_MINUS_DST_COLOR`      | 775   |
-| `ONE_MINUS_SRC_ALPHA`      | 771   |
-| `ONE_MINUS_SRC_COLOR`      | 769   |
-| `SRC_ALPHA`                | 770   |
 | `SRC_COLOR`                | 768   |
 | `ZERO`                     | 0     |
 

--- a/docs/blend.md
+++ b/docs/blend.md
@@ -1,6 +1,6 @@
 # Blend Mode
-The mod uses `glBlendFunc(sourceFactor, destinationFactor)` and `glBlendEquation(equation)` to blend the textured sky boxes.
-[[Online Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php)]
+The mod uses [glBlendFunc(sourceFactor, destinationFactor)](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml) and [glBlendEquation(equation)](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml) to blend the textured sky boxes.
+[[Online Visualize Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php)]
 
 Using the example below to achieve the burn blend effect.
 
@@ -17,7 +17,6 @@ glBlendEquation(ADD);
   "equation": 32774
 }
 ```
-
 
 
 ### Source/Destination Factor

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -184,7 +184,7 @@ Specifies the blend type or equation.
 | `dFactor` | Integer | Specifies the OpenGL destination factor to use.  |    :x:    |
 | `equation` | Integer | Specifies the OpenGL blend equation to use. | :x: |
 
-Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha`, `dodge` and `burn`.
+Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha`, `dodge`, `burn`, `darken` and `lighten`.
 
 More information on custom blend [here](blend.md).
 

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -184,7 +184,7 @@ Specifies the blend type or equation.
 | `dFactor` | Integer | Specifies the OpenGL destination factor to use.  |    :x:    |
 | `equation` | Integer | Specifies the OpenGL blend equation to use. | :x: |
 
-Valid types are: `add`, `subtract`, `multiply`, `screen`, and `replace`.
+Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha` and `burn`.
 
 More information on custom blend [here](blend.md).
 

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -184,7 +184,7 @@ Specifies the blend type or equation.
 | `dFactor` | Integer | Specifies the OpenGL destination factor to use.  |    :x:    |
 | `equation` | Integer | Specifies the OpenGL blend equation to use. | :x: |
 
-Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha` and `burn`.
+Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha`, `dodge` and `burn`.
 
 More information on custom blend [here](blend.md).
 

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -186,6 +186,8 @@ Specifies the blend type or equation.
 
 Valid types are: `add`, `subtract`, `multiply`, `screen`, and `replace`.
 
+More information on custom blend [here](blend.md).
+
 **Example**
 
 ```json

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
@@ -6,10 +6,12 @@ import io.github.amerebagatelle.fabricskyboxes.skyboxes.AbstractSkybox;
 import io.github.amerebagatelle.fabricskyboxes.skyboxes.RotatableSkybox;
 import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.*;
+import net.minecraft.client.render.BufferBuilder;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.CameraSubmersionType;
+import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.util.math.Matrix4f;
@@ -55,7 +57,7 @@ public abstract class TexturedSkybox extends AbstractSkybox implements Rotatable
         RenderSystem.enableBlend();
 
         blend.applyBlendFunc();
-        RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F); // Todo: Calculate our brightness based off position of the player and biomes/height ranges/weather and move this into Blend.
 
         ClientWorld world = Objects.requireNonNull(MinecraftClient.getInstance().world);
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -7,13 +7,15 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.amerebagatelle.fabricskyboxes.FabricSkyBoxesClient;
 import org.lwjgl.opengl.GL14;
 
+import java.util.Arrays;
+
 public class Blend {
     public static final Blend DEFAULT = new Blend("", 0, 0, 0);
     public static Codec<Blend> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.optionalFieldOf("type", "").forGetter(Blend::getType),
             Codec.INT.optionalFieldOf("sFactor", -1).forGetter(Blend::getSFactor),
             Codec.INT.optionalFieldOf("dFactor", -1).forGetter(Blend::getDFactor),
-            Codec.INT.optionalFieldOf("equation", 0).forGetter(Blend::getEquation)
+            Codec.INT.optionalFieldOf("equation", -1).forGetter(Blend::getEquation)
     ).apply(instance, Blend::new));
     private final String type;
     private final int sFactor;
@@ -32,30 +34,30 @@ public class Blend {
             switch (type) {
                 case "add" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(GL14.GL_FUNC_ADD);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "subtract" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(GL14.GL_FUNC_SUBTRACT);
+                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
                 };
                 case "multiply" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ZERO);
-                    RenderSystem.blendEquation(GL14.GL_FUNC_ADD);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "screen" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
-                    RenderSystem.blendEquation(GL14.GL_FUNC_ADD);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "replace" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(GL14.GL_FUNC_ADD);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 default -> {
                     FabricSkyBoxesClient.getLogger().error("Blend mode is set to an invalid or unsupported value.");
                     blendFunc = RenderSystem::defaultBlendFunc;
                 }
             }
-        } else if (sFactor != -1 && dFactor != -1) {
+        } else if (this.isValidSourceFactor(sFactor) && this.isValidDestinationFactor(dFactor) && this.isValidEquation(equation)) {
             blendFunc = () -> {
                 RenderSystem.blendFunc(sFactor, dFactor);
                 RenderSystem.blendEquation(equation);
@@ -83,5 +85,31 @@ public class Blend {
 
     public int getEquation() {
         return equation;
+    }
+
+    public boolean isValidSourceFactor(int sFactor) {
+        return Arrays.stream(GlStateManager.SrcFactor.values()).filter(srcFactor -> sFactor == srcFactor.value).count() == 1;
+    }
+
+    public boolean isValidDestinationFactor(int dFactor) {
+        return Arrays.stream(GlStateManager.DstFactor.values()).filter(dstFactor -> dFactor == dstFactor.value).count() == 1;
+    }
+
+    public boolean isValidEquation(int equation) {
+        return Arrays.stream(Equation.values()).filter(equation1 -> equation == equation1.value).count() == 1;
+    }
+
+    public enum Equation {
+        ADD(GL14.GL_FUNC_ADD),
+        SUBTRACT(GL14.GL_FUNC_SUBTRACT),
+        REVERSE_SUBTRACT(GL14.GL_FUNC_REVERSE_SUBTRACT),
+        MIN(GL14.GL_MIN),
+        MAX(GL14.GL_MAX);
+
+        public final int value;
+
+        Equation(int value) {
+            this.value = value;
+        }
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -65,7 +65,7 @@ public class Blend {
                     blendFunc = RenderSystem::defaultBlendFunc;
                 }
             }
-        } else if (this.isValidSourceFactor(sFactor) && this.isValidDestinationFactor(dFactor) && this.isValidEquation(equation)) {
+        } else if (this.isValidFactor(sFactor) && this.isValidFactor(dFactor) && this.isValidEquation(equation)) {
             blendFunc = () -> {
                 RenderSystem.blendFunc(sFactor, dFactor);
                 RenderSystem.blendEquation(equation);
@@ -95,12 +95,8 @@ public class Blend {
         return equation;
     }
 
-    public boolean isValidSourceFactor(int sFactor) {
-        return Arrays.stream(GlStateManager.SrcFactor.values()).filter(srcFactor -> sFactor == srcFactor.value).count() == 1;
-    }
-
-    public boolean isValidDestinationFactor(int dFactor) {
-        return Arrays.stream(GlStateManager.DstFactor.values()).filter(dstFactor -> dFactor == dstFactor.value).count() == 1;
+    public boolean isValidFactor(int factor) {
+        return Arrays.stream(GlStateManager.SrcFactor.values()).filter(factor1 -> factor == factor1.value).count() == 1;
     }
 
     public boolean isValidEquation(int equation) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -33,15 +33,15 @@ public class Blend {
         if (!type.isEmpty()) {
             switch (type) {
                 case "add" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE);
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "subtract" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE_MINUS_DST_COLOR, GlStateManager.DstFactor.ZERO);
                     RenderSystem.blendEquation(Equation.SUBTRACT.value);
                 };
                 case "multiply" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ZERO);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "screen" -> blendFunc = () -> {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -52,6 +52,14 @@ public class Blend {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE);
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
+                case "alpha" -> blendFunc = () -> {
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+                    RenderSystem.blendEquation(Equation.ADD.value);
+                };
+                case "burn" -> blendFunc = () -> {
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
+                    RenderSystem.blendEquation(Equation.ADD.value);
+                };
                 default -> {
                     FabricSkyBoxesClient.getLogger().error("Blend mode is set to an invalid or unsupported value.");
                     blendFunc = RenderSystem::defaultBlendFunc;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -38,11 +38,11 @@ public class Blend {
                 };
                 case "subtract" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE_MINUS_DST_COLOR, GlStateManager.DstFactor.ZERO);
-                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "multiply" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
-                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ZERO);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "screen" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
@@ -61,8 +61,16 @@ public class Blend {
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "dodge" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE);
                     RenderSystem.blendEquation(Equation.ADD.value);
+                };
+                case "darken" -> blendFunc = () -> {
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendEquation(Equation.MIN.value);
+                };
+                case "lighten" -> blendFunc = () -> {
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendEquation(Equation.MAX.value);
                 };
                 default -> {
                     FabricSkyBoxesClient.getLogger().error("Blend mode is set to an invalid or unsupported value.");

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -60,6 +60,10 @@ public class Blend {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
+                case "dodge" -> blendFunc = () -> {
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendEquation(Equation.ADD.value);
+                };
                 default -> {
                     FabricSkyBoxesClient.getLogger().error("Blend mode is set to an invalid or unsupported value.");
                     blendFunc = RenderSystem::defaultBlendFunc;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -42,7 +42,7 @@ public class Blend {
                 };
                 case "multiply" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
                 };
                 case "screen" -> blendFunc = () -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
@@ -53,7 +53,7 @@ public class Blend {
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "alpha" -> blendFunc = () -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
                     RenderSystem.blendEquation(Equation.ADD.value);
                 };
                 case "burn" -> blendFunc = () -> {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -11,8 +11,8 @@ public class Blend {
     public static final Blend DEFAULT = new Blend("", 0, 0, 0);
     public static Codec<Blend> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.optionalFieldOf("type", "").forGetter(Blend::getType),
-            Codec.INT.optionalFieldOf("sFactor", 0).forGetter(Blend::getSFactor),
-            Codec.INT.optionalFieldOf("dFactor", 0).forGetter(Blend::getDFactor),
+            Codec.INT.optionalFieldOf("sFactor", -1).forGetter(Blend::getSFactor),
+            Codec.INT.optionalFieldOf("dFactor", -1).forGetter(Blend::getDFactor),
             Codec.INT.optionalFieldOf("equation", 0).forGetter(Blend::getEquation)
     ).apply(instance, Blend::new));
     private final String type;
@@ -55,7 +55,7 @@ public class Blend {
                     blendFunc = RenderSystem::defaultBlendFunc;
                 }
             }
-        } else if (sFactor != 0 && dFactor != 0) {
+        } else if (sFactor != -1 && dFactor != -1) {
             blendFunc = () -> {
                 RenderSystem.blendFunc(sFactor, dFactor);
                 RenderSystem.blendEquation(equation);


### PR DESCRIPTION
~~This would be preferable to be boxed but the Codec doesn't appear to support boxed primitives. The source & destination factors' values should never be negative anyway.~~

This PR allows resource pack makers to assign `0` to source and destination factors for blend mode. Additionally, it performs a check for valid source, destination, and equation values.

Changes:
- [x] Update documentation to have a list of values for source/destination factors and equations values
- [x] Change shader color instead of shader (This should resolve #26)
- [x] Adjust existing blend modes
- [x] Perform a check for valid source, destination, and equation values
- [x] Addition of `alpha`, `darken`, `lighten`, `dodge` and `burn` blend modes 
  - `dodge` and `burn` are not accurate; this would require a shader.