### PR TITLE
Check effects in abstract skybox

### DIFF
--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -1,7 +1,6 @@
 package io.github.amerebagatelle.fabricskyboxes.skyboxes;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Range;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -14,8 +13,7 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.effect.StatusEffect;
-import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -25,7 +23,6 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -213,7 +210,6 @@ public abstract class AbstractSkybox {
     protected boolean checkEffect() {
         MinecraftClient client = MinecraftClient.getInstance();
         Objects.requireNonNull(client.world);
-        Objects.requireNonNull(client.player);
 
         Camera camera = client.gameRenderer.getCamera();
         boolean thickFog = client.world.getDimensionEffects().useThickFog(MathHelper.floor(camera.getPos().getX()), MathHelper.floor(camera.getPos().getY())) || client.inGameHud.getBossBarHud().shouldThickenFog();
@@ -224,16 +220,9 @@ public abstract class AbstractSkybox {
         if (cameraSubmersionType == CameraSubmersionType.POWDER_SNOW || cameraSubmersionType == CameraSubmersionType.LAVA)
             return false;
 
-        ClientPlayerEntity player = client.player;
-        Collection<StatusEffectInstance> activeEffects = player.getStatusEffects();
-        if (!activeEffects.isEmpty()) {
-            for (StatusEffectInstance statusEffectInstance : Ordering.natural().reverse().sortedCopy(activeEffects)) {
-                StatusEffect statusEffect = statusEffectInstance.getEffectType();
-                if (statusEffect.equals(StatusEffects.BLINDNESS)) {
-                    return false;
-                }
-            }
-        }
+        if (camera.getFocusedEntity() instanceof LivingEntity livingEntity && livingEntity.hasStatusEffect(StatusEffects.BLINDNESS))
+            return false;
+
         return true;
     }
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/MonoColorSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/MonoColorSkybox.java
@@ -13,8 +13,6 @@ import net.minecraft.client.gl.VertexBuffer;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Matrix4f;
 import net.minecraft.util.math.Vec3f;
@@ -45,18 +43,6 @@ public class MonoColorSkybox extends AbstractSkybox {
 
     @Override
     public void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
-        if (thickFog)
-            return;
-
-        CameraSubmersionType cameraSubmersionType = camera.getSubmersionType();
-        if (cameraSubmersionType == CameraSubmersionType.POWDER_SNOW || cameraSubmersionType == CameraSubmersionType.LAVA)
-            return;
-
-        if (camera.getFocusedEntity() instanceof LivingEntity livingEntity) {
-            if (livingEntity.hasStatusEffect(StatusEffects.BLINDNESS))
-                return;
-        }
-
         if (this.alpha > 0) {
             RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
             MinecraftClient client = MinecraftClient.getInstance();

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
@@ -8,12 +8,9 @@ import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.Camera;
-import net.minecraft.client.render.CameraSubmersionType;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.util.math.Matrix4f;
 import net.minecraft.util.math.Vec3f;
 
@@ -41,18 +38,6 @@ public abstract class TexturedSkybox extends AbstractSkybox implements Rotatable
      */
     @Override
     public final void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
-        if (thickFog)
-            return;
-
-        CameraSubmersionType cameraSubmersionType = camera.getSubmersionType();
-        if (cameraSubmersionType == CameraSubmersionType.POWDER_SNOW || cameraSubmersionType == CameraSubmersionType.LAVA)
-            return;
-
-        if (camera.getFocusedEntity() instanceof LivingEntity livingEntity) {
-            if (livingEntity.hasStatusEffect(StatusEffects.BLINDNESS))
-                return;
-        }
-
         RenderSystem.depthMask(false);
         RenderSystem.enableBlend();
 


### PR DESCRIPTION
In my previous PR #35, I added vanilla effects checks directly hardcoded to prevent the skybox from rendering. This PR moves them to the proper location.