### PR TITLE
Fix fog colors not applying properly

### DIFF
--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/FogColorMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/FogColorMixin.java
@@ -25,7 +25,7 @@ public class FogColorMixin {
     /**
      * Checks if we should change the fog color to whatever the skybox set it to, and sets it.
      */
-    @Inject(method = "render(Lnet/minecraft/client/render/Camera;FLnet/minecraft/client/world/ClientWorld;IF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/BackgroundRenderer;lastWaterFogColorUpdateTime:J", ordinal = 5))
+    @Inject(method = "render(Lnet/minecraft/client/render/Camera;FLnet/minecraft/client/world/ClientWorld;IF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/BackgroundRenderer;lastWaterFogColorUpdateTime:J", ordinal = 6))
     private static void modifyColors(Camera camera, float tickDelta, ClientWorld world, int i, float f, CallbackInfo ci) {
         if (SkyboxManager.shouldChangeFog) {
             red = SkyboxManager.fogRed;


### PR DESCRIPTION
This pull request fixes #65. It changes the mixin injection target to account for the powder snow submersion view. (Yup this was broken since 1.17 and no one noticed)

Before pull request
![image](https://user-images.githubusercontent.com/30311066/197177928-389f4f8e-5cb4-4cee-9603-347d64b7e2b9.png)

After pull request
![image](https://user-images.githubusercontent.com/30311066/197177500-256bc77a-5a9f-478f-9ff7-fc1bbbd7243a.png)
