### PR TITLE
Refactor fade system

### DIFF
--- a/docs/blend.md
+++ b/docs/blend.md
@@ -1,26 +1,31 @@
 # Blend Mode
-The mod uses [glBlendFunc(sourceFactor, destinationFactor)](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml) and [glBlendEquation(equation)](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml) to blend the textured sky boxes.
-[[Online Visualize Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php)]  
-In FabricSkyboxes, you must specify an integer for `sFactor`, `dFactor`, and `equation`, corresponding to `sourceFactor` and `destinationFactor` from `glBlendFunc`, and `equation` from `glBlendEquation`, respectively. A table is provided below for supported enums and their corresponding integer values.
+The mod uses [glBlendFunc](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml) and [glBlendEquation](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml) to blend the textured sky boxes. To get a better understanding of the blending functions and equations, you can use an [Online Visualize Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php).
 
-Using the example below to achieve the burn blend effect.
+In FabricSkyboxes, you must specify an integer value for `sFactor`, `dFactor`, and `equation`, corresponding to the `sourceFactor` and `destinationFactor` from `glBlendFunc`, and `equation` from `glBlendEquation`, respectively. A table of supported enums and their corresponding integer values is provided below.
 
-##### Burn Blend Mode
-FabricSkyboxes predicate `"blend"`:
+Here's an example of how to achieve the burn blend effect in FabricSkyboxes:
+
+#### Burn Blend Mode
+In the `"blend"` property of FabricSkyboxes, specify the following JSON:
 ```json
 {
   "sFactor": 0,
   "dFactor": 769,
-  "equation": 32774
+  "equation": 32774,
+  "redAlphaEnabled": true,
+  "greenAlphaEnabled": true,
+  "blueAlphaEnabled": true,
+  "alphaEnabled": false
 }
 ```
 
-Corresponding OpenGL code:  
+This corresponds to the following OpenGL code:
 ```java
 glBlendFunc(ZERO, ONE_MINUS_SRC_COLOR);
 glBlendEquation(ADD);
+setShaderColor(RED, GREEN, BLUE, ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
 ```
-Note that unlike normal OpenGL, FabricSkyboxes does not support enums. Instead, you will need to specify an integer value.
+Note that unlike in normal OpenGL, FabricSkyboxes does not support enums. You must specify an integer value.
 
 
 ### Source/Destination Factor

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -170,8 +170,16 @@ The basic structure of a fabricskyboxes skybox file may look something like this
     /* sFactor number (int, optional) */
     "dFactor": 0,
     /* dFactor number (int, optional) */
-    "equation": 0
+    "equation": 0,
     /* equation number (int, optional) */
+    "redAlphaEnabled": false,
+    /* red alpha state (boolean, optional) */
+    "greenAlphaEnabled": false,
+    /* green alpha state (boolean, optional) */
+    "blueAlphaEnabled": false,
+    /* blue alpha state (boolean, optional) */
+    "alphaEnabled": true
+    /* alpha state (boolean, optional) */
   },
   "textures": // textures object (square-textured type only)
   {
@@ -669,12 +677,16 @@ Specifies the blend type or equation.
 
 **Specification**
 
-|    Name    | Datatype |                   Description                   | Required |
-|:----------:|:--------:|:-----------------------------------------------:|:--------:|
-|   `type`   |  String  |        Specifies the type of the blend.         |   :x:    |
-| `sFactor`  | Integer  |   Specifies the OpenGL source factor to use.    |   :x:    |
-| `dFactor`  | Integer  | Specifies the OpenGL destination factor to use. |   :x:    |
-| `equation` | Integer  |   Specifies the OpenGL blend equation to use.   |   :x:    |
+|        Name         | Datatype |                                            Description                                            | Required | Default value |
+|:-------------------:|:--------:|:-------------------------------------------------------------------------------------------------:|:--------:|:--------------|
+|       `type`        |  String  |                                 Specifies the type of the blend.                                  |   :x:    |               |
+|      `sFactor`      | Integer  |                            Specifies the OpenGL source factor to use.                             |   :x:    |               |
+|      `dFactor`      | Integer  |                          Specifies the OpenGL destination factor to use.                          |   :x:    |               |
+|     `equation`      | Integer  |                            Specifies the OpenGL blend equation to use.                            |   :x:    |               |
+|  `redAlphaEnabled`  | Boolean  |  Specifies whether alpha state will be used in red shader color or predetermined value of `1.0`.  |   :x:    | false         |
+| `greenAlphaEnabled` | Boolean  | Specifies whether alpha state will be used in green shader color or predetermined value of `1.0`. |   :x:    | false         |
+| `blueAlphaEnabled`  | Boolean  | Specifies whether alpha state will be used in blue shader color or predetermined value of `1.0`.  |   :x:    | false         |
+|   `alphaEnabled`    | Boolean  |    Specifies whether alpha state will be used in shader color or predetermined value of `1.0`.    |   :x:    | true          |
 
 Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha`, `dodge`, `burn`, `darken` and `lighten`.
 
@@ -694,7 +706,11 @@ More information on custom blend can be found in the [blend documentation](blend
 {
   "sFactor": 0,
   "dFactor": 0,
-  "equation": 0
+  "equation": 0,
+  "redAlphaEnabled": true,
+  "greenAlphaEnabled": true,
+  "blueAlphaEnabled": true,
+  "alphaEnabled": false
 }
 ```
 

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -115,8 +115,10 @@ The basic structure of a fabricskyboxes skybox file may look something like this
     },
     "maxAlpha": 0,
     /* max alpha value (0-1 float, optional) */
-    "transitionSpeed": 0,
-    /* fade in/out speed (0-1 float, optional) */
+    "transitionInDuration": 20,
+    /* fade in speed (1-8760000 float, optional) */
+    "transitionOutDuration": 20,
+    /* fade out speed (1-8760000 float, optional) */
     "changeFog": false,
     /* change fog color (bool, optional) */
     "fogColors": // RGBA object for fog color (optional)
@@ -326,18 +328,19 @@ Specifies common properties used by all types of skyboxes.
 
 **Specification**
 
-|       Name        |              Datatype               |                                                                                                           Description                                                                                                            |      Required      | Default value                                |
-|:-----------------:|:-----------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------:|----------------------------------------------|
-|    `priority`     |               Integer               | Specifies the order which skybox will be rendered. If there are multiple skyboxes with identical priority, those skyboxes are not re-ordered therefore being dependant of Vanilla's alphabetical namespaced identifiers loading. |        :x:         | 0                                            |
-|      `fade`       |     [Fade object](#fade-object)     |                                                                    Specifies the time of day in ticks that the skybox should start and end fading in and out.                                                                    | :white_check_mark: | -                                            |
-|    `maxAlpha`     |                Float                |                                                                       Specifies the maximum value that the alpha can be. The value must be within 0 and 1.                                                                       |        :x:         | 1.0                                          |
-| `transitionSpeed` |                Float                |                                                     Specifies the speed that skybox will fade in or out when valid conditions are changed. The value must be within 0 and 1.                                                     |        :x:         | 1.0                                          |
-|    `changeFog`    |               Boolean               |                                                                                    Specifies whether the skybox should change the fog color.                                                                                     |        :x:         | `false`                                      |
-|    `fogColors`    |     [RGBA Object](#rgba-object)     |                                                                                        Specifies the colors to be used for rendering fog.                                                                                        |        :x:         | 0 for each value                             |
-|   `sunSkyTint`    |               Boolean               |                                                                            Specifies whether the skybox should disable sunrise/set sky color tinting                                                                             |        :x:         | `true`                                       |
-|   `inThickFog`    |               Boolean               |                                                                                  Specifies whether the skybox should be rendered in thick fog.                                                                                   |        :x:         | `true`                                       |
-|  `shouldRotate`   |               Boolean               |                                                                                     Specifies whether the skybox should rotate on its axis.                                                                                      |        :x:         | `false`                                      |
-|    `rotation`     | [Rotation object](#rotation-object) |                                                                                           Specifies the rotation angles of the skybox.                                                                                           |        :x:         | [0,0,0] for static/axis, 1 for rotationSpeed |
+|          Name           |              Datatype               |                                                                                                           Description                                                                                                            |      Required      | Default value                                |
+|:-----------------------:|:-----------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------:|----------------------------------------------|
+|       `priority`        |               Integer               | Specifies the order which skybox will be rendered. If there are multiple skyboxes with identical priority, those skyboxes are not re-ordered therefore being dependant of Vanilla's alphabetical namespaced identifiers loading. |        :x:         | 0                                            |
+|         `fade`          |     [Fade object](#fade-object)     |                                                                    Specifies the time of day in ticks that the skybox should start and end fading in and out.                                                                    | :white_check_mark: | -                                            |
+|       `maxAlpha`        |                Float                |                                                                       Specifies the maximum value that the alpha can be. The value must be within 0 and 1.                                                                       |        :x:         | 1.0                                          |
+| `transitionInDuration`  |               Integer               |                                   Specifies the duration in ticks that skybox will fade in when valid conditions are changed. The value must be within 1 and 8760000 (365 days * 24000 ticks).                                   |        :x:         | 20                                           |
+| `transitionOutDuration` |               Integer               |                                   Specifies the duration in ticks that skybox will fade in when valid conditions are changed. The value must be within 1 and 8760000 (365 days * 24000 ticks).                                   |        :x:         | 20                                           |
+|       `changeFog`       |               Boolean               |                                                                                    Specifies whether the skybox should change the fog color.                                                                                     |        :x:         | `false`                                      |
+|       `fogColors`       |     [RGBA Object](#rgba-object)     |                                                                                        Specifies the colors to be used for rendering fog.                                                                                        |        :x:         | 0 for each value                             |
+|      `sunSkyTint`       |               Boolean               |                                                                            Specifies whether the skybox should disable sunrise/set sky color tinting                                                                             |        :x:         | `true`                                       |
+|      `inThickFog`       |               Boolean               |                                                                                  Specifies whether the skybox should be rendered in thick fog.                                                                                   |        :x:         | `true`                                       |
+|     `shouldRotate`      |               Boolean               |                                                                                     Specifies whether the skybox should rotate on its axis.                                                                                      |        :x:         | `false`                                      |
+|       `rotation`        | [Rotation object](#rotation-object) |                                                                                           Specifies the rotation angles of the skybox.                                                                                           |        :x:         | [0,0,0] for static/axis, 1 for rotationSpeed |
 
 **Example**
 
@@ -351,7 +354,8 @@ Specifies common properties used by all types of skyboxes.
     "endFadeOut": 4000
   },
   "maxAlpha": 0.5,
-  "transitionSpeed": 0.8,
+  "transitionInDuration": 20,
+  "transitionOutDuration": 20,
   "sunSkyTint": false,
   "inThickFog": true,
   "changeFog": true,
@@ -761,7 +765,8 @@ Here is a full skybox file for example purposes:
       "alwaysOn": true
     },
     "maxAlpha": 1.0,
-    "transitionSpeed": 1.0,
+    "transitionInDuration": 20,
+    "transitionOutDuration": 20,
     "sunSkyTint": true,
     "inThickFog": true,
     "changeFog": true,

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/FabricSkyBoxesClient.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/FabricSkyBoxesClient.java
@@ -34,6 +34,7 @@ public class FabricSkyBoxesClient implements ClientModInitializer {
         SkyboxType.initRegistry();
         toggleFabricSkyBoxes = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabricskyboxes.toggle", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_KP_0, "category.fabricskyboxes"));
         ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(new SkyboxResourceListener());
+        ClientTickEvents.END_CLIENT_TICK.register(SkyboxManager.getInstance());
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (toggleFabricSkyBoxes.wasPressed()) {
                 SkyboxManager.getInstance().setEnabled(!SkyboxManager.getInstance().isEnabled());

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTick {
-    public static final double MINIMUM_ALPHA = 0.001;
     private static final SkyboxManager INSTANCE = new SkyboxManager();
     private final Map<Identifier, Skybox> skyboxMap = new Object2ObjectLinkedOpenHashMap<>();
     /**

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -177,7 +177,7 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
 
     @Override
     public void onEndTick(MinecraftClient client) {
-        if (MinecraftClient.getInstance().world == null)
+        if (MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().isPaused())
             return;
 
         this.totalAlpha = (float) StreamSupport

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -13,6 +13,8 @@ import io.github.amerebagatelle.fabricskyboxes.skyboxes.SkyboxType;
 import io.github.amerebagatelle.fabricskyboxes.util.JsonObjectWrapper;
 import io.github.amerebagatelle.fabricskyboxes.util.object.internal.Metadata;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
@@ -27,7 +29,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class SkyboxManager implements FabricSkyBoxesApi {
+public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTick {
     public static final double MINIMUM_ALPHA = 0.001;
     private static final SkyboxManager INSTANCE = new SkyboxManager();
     private final Map<Identifier, Skybox> skyboxMap = new Object2ObjectLinkedOpenHashMap<>();
@@ -42,6 +44,7 @@ public class SkyboxManager implements FabricSkyBoxesApi {
     private Skybox currentSkybox = null;
     private boolean enabled = true;
     private boolean decorationsRendered;
+    private float totalAlpha = 0f;
 
     public static AbstractSkybox parseSkyboxJson(Identifier id, JsonObjectWrapper objectWrapper) {
         AbstractSkybox skybox;
@@ -129,11 +132,7 @@ public class SkyboxManager implements FabricSkyBoxesApi {
 
     @Internal
     public float getTotalAlpha() {
-        return (float) StreamSupport
-                .stream(Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values()).spliterator(), false)
-                .filter(FSBSkybox.class::isInstance)
-                .map(FSBSkybox.class::cast)
-                .mapToDouble(FSBSkybox::updateAlpha).sum();
+        return this.totalAlpha;
     }
 
     @Internal
@@ -148,7 +147,6 @@ public class SkyboxManager implements FabricSkyBoxesApi {
             this.currentSkybox = skybox;
             skybox.render(worldRendererAccess, matrices, matrix4f, tickDelta, camera, thickFog);
         });
-        this.activeSkyboxes.removeIf(skybox -> !skybox.isActiveLater());
     }
 
     @Internal
@@ -176,5 +174,19 @@ public class SkyboxManager implements FabricSkyBoxesApi {
     @Override
     public int getApiVersion() {
         return 0;
+    }
+
+    @Override
+    public void onEndTick(MinecraftClient client) {
+        if (MinecraftClient.getInstance().world == null)
+            return;
+
+        this.totalAlpha = (float) StreamSupport
+                .stream(Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values()).spliterator(), false)
+                .filter(FSBSkybox.class::isInstance)
+                .map(FSBSkybox.class::cast)
+                .mapToDouble(FSBSkybox::updateAlpha).sum();
+
+        this.activeSkyboxes.removeIf(skybox -> !skybox.isActiveLater());
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/FogColorMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/FogColorMixin.java
@@ -3,6 +3,7 @@ package io.github.amerebagatelle.fabricskyboxes.mixin.skybox;
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.FSBSkybox;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.Skybox;
+import io.github.amerebagatelle.fabricskyboxes.util.Constants;
 import net.minecraft.client.render.BackgroundRenderer;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.world.ClientWorld;
@@ -30,7 +31,7 @@ public class FogColorMixin {
     @Inject(method = "render(Lnet/minecraft/client/render/Camera;FLnet/minecraft/client/world/ClientWorld;IF)V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/BackgroundRenderer;lastWaterFogColorUpdateTime:J", ordinal = 6))
     private static void modifyColors(Camera camera, float tickDelta, ClientWorld world, int i, float f, CallbackInfo ci) {
         Skybox skybox = SkyboxManager.getInstance().getCurrentSkybox();
-        if (skybox instanceof FSBSkybox fsbSkybox && fsbSkybox.getAlpha() > SkyboxManager.MINIMUM_ALPHA && fsbSkybox.getProperties().isChangeFog()) {
+        if (skybox instanceof FSBSkybox fsbSkybox && fsbSkybox.getAlpha() > Constants.MINIMUM_ALPHA && fsbSkybox.getProperties().isChangeFog()) {
             red = fsbSkybox.getProperties().getFogColors().getRed();
             green = fsbSkybox.getProperties().getFogColors().getGreen();
             blue = fsbSkybox.getProperties().getFogColors().getBlue();

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
@@ -1,6 +1,7 @@
 package io.github.amerebagatelle.fabricskyboxes.mixin.skybox;
 
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
+import io.github.amerebagatelle.fabricskyboxes.util.Constants;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -22,7 +23,7 @@ public class SkyboxRenderMixin {
             runnable.run();
             float total = skyboxManager.getTotalAlpha();
             skyboxManager.renderSkyboxes((WorldRendererAccess) this, matrices, matrix4f, tickDelta, camera, bl);
-            if (total > SkyboxManager.MINIMUM_ALPHA) {
+            if (total > Constants.MINIMUM_ALPHA) {
                 ci.cancel();
             }
         }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -327,6 +327,11 @@ public abstract class AbstractSkybox implements FSBSkybox {
 
     @Override
     public boolean isActiveLater() {
-        return this.updateAlpha() > Constants.MINIMUM_ALPHA;
+        final float oldAlpha = this.alpha;
+        if (this.updateAlpha() > Constants.MINIMUM_ALPHA) {
+            this.alpha = oldAlpha;
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -107,7 +107,9 @@ public abstract class AbstractSkybox implements FSBSkybox {
             }
         }
 
-        return MathHelper.clamp(this.alpha, 0f, this.properties.getMaxAlpha());
+        this.alpha = MathHelper.clamp(this.alpha, 0f, this.properties.getMaxAlpha());
+
+        return this.alpha;
     }
 
     /**

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -41,8 +41,8 @@ public abstract class AbstractSkybox implements FSBSkybox {
     protected Properties properties;
     protected Conditions conditions = Conditions.DEFAULT;
     protected Decorations decorations = Decorations.DEFAULT;
-    private Float unexpectedFadeInTime = null;
-    private Float unexpectedFadeOutTime = null;
+    private Float fadeInDelta = null;
+    private Float fadeOutDelta = null;
 
     protected AbstractSkybox() {
     }
@@ -71,38 +71,38 @@ public abstract class AbstractSkybox implements FSBSkybox {
     public final float updateAlpha() {
         int currentTime = (int) (Objects.requireNonNull(MinecraftClient.getInstance().world).getTimeOfDay() % 24000);
 
-        boolean shouldRender = Utils.isWithinDuration(currentTime, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getStartFadeOut() - 1);
+        boolean shouldRender = Utils.isInTimeInterval(currentTime, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getStartFadeOut() - 1);
 
         if ((shouldRender || this.properties.getFade().isAlwaysOn()) && checkBiomes() && checkXRanges() && checkYRanges() && checkZRanges() && checkWeather() && checkEffect() && checkLoop()) {
             if (this.alpha < this.properties.getMaxAlpha()) {
                 // Check if currentTime is at the beginning of fadeIn
-                if (this.properties.getFade().getStartFadeIn() == currentTime && this.unexpectedFadeInTime == null) {
-                    float f1 = Utils.getPosition(this.properties.getMaxAlpha(), currentTime, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getEndFadeIn());
-                    float f2 = Utils.getPosition(this.properties.getMaxAlpha(), currentTime + 1, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getEndFadeIn());
-                    this.unexpectedFadeInTime = f2 - f1;
+                if (this.properties.getFade().getStartFadeIn() == currentTime && this.fadeInDelta == null) {
+                    float f1 = Utils.normalizeTime(this.properties.getMaxAlpha(), currentTime, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getEndFadeIn());
+                    float f2 = Utils.normalizeTime(this.properties.getMaxAlpha(), currentTime + 1, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getEndFadeIn());
+                    this.fadeInDelta = f2 - f1;
                 }
 
-                this.alpha += Objects.requireNonNullElseGet(this.unexpectedFadeInTime, () -> this.properties.getTransitionSpeed());
+                this.alpha += Objects.requireNonNullElseGet(this.fadeInDelta, () -> this.properties.getTransitionSpeed());
             } else {
                 this.alpha = this.properties.getMaxAlpha();
-                if (this.unexpectedFadeInTime != null) {
-                    this.unexpectedFadeInTime = null;
+                if (this.fadeInDelta != null) {
+                    this.fadeInDelta = null;
                 }
             }
         } else {
             if (this.alpha > 0f) {
                 // Check if currentTime is at the beginning of fadeOut
-                if (this.properties.getFade().getStartFadeOut() == currentTime && this.unexpectedFadeOutTime == null) {
-                    float f1 = Utils.getPosition(this.properties.getMaxAlpha(), currentTime, this.properties.getFade().getStartFadeOut(), this.properties.getFade().getEndFadeOut());
-                    float f2 = Utils.getPosition(this.properties.getMaxAlpha(), currentTime + 1, this.properties.getFade().getStartFadeOut(), this.properties.getFade().getEndFadeOut());
-                    this.unexpectedFadeOutTime = f2 - f1;
+                if (this.properties.getFade().getStartFadeOut() == currentTime && this.fadeOutDelta == null) {
+                    float f1 = Utils.normalizeTime(this.properties.getMaxAlpha(), currentTime, this.properties.getFade().getStartFadeOut(), this.properties.getFade().getEndFadeOut());
+                    float f2 = Utils.normalizeTime(this.properties.getMaxAlpha(), currentTime + 1, this.properties.getFade().getStartFadeOut(), this.properties.getFade().getEndFadeOut());
+                    this.fadeOutDelta = f2 - f1;
                 }
 
-                this.alpha -= Objects.requireNonNullElseGet(this.unexpectedFadeOutTime, () -> this.properties.getTransitionSpeed());
+                this.alpha -= Objects.requireNonNullElseGet(this.fadeOutDelta, () -> this.properties.getTransitionSpeed());
             } else {
                 this.alpha = 0f;
-                if (this.unexpectedFadeOutTime != null) {
-                    this.unexpectedFadeOutTime = null;
+                if (this.fadeOutDelta != null) {
+                    this.fadeOutDelta = null;
                 }
             }
         }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.FSBSkybox;
 import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
+import io.github.amerebagatelle.fabricskyboxes.util.Constants;
 import io.github.amerebagatelle.fabricskyboxes.util.Utils;
 import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.MinecraftClient;
@@ -82,7 +83,7 @@ public abstract class AbstractSkybox implements FSBSkybox {
                     this.fadeInDelta = f2 - f1;
                 }
 
-                this.alpha += Objects.requireNonNullElseGet(this.fadeInDelta, () -> this.properties.getTransitionSpeed());
+                this.alpha += Objects.requireNonNullElseGet(this.fadeInDelta, () -> this.properties.getMaxAlpha() / this.properties.getTransitionInDuration());
             } else {
                 this.alpha = this.properties.getMaxAlpha();
                 if (this.fadeInDelta != null) {
@@ -98,16 +99,16 @@ public abstract class AbstractSkybox implements FSBSkybox {
                     this.fadeOutDelta = f2 - f1;
                 }
 
-                this.alpha -= Objects.requireNonNullElseGet(this.fadeOutDelta, () -> this.properties.getTransitionSpeed());
+                this.alpha -= Objects.requireNonNullElseGet(this.fadeOutDelta, () -> this.properties.getMaxAlpha() / this.properties.getTransitionOutDuration());
             } else {
-                this.alpha = 0f;
+                this.alpha = 0F;
                 if (this.fadeOutDelta != null) {
                     this.fadeOutDelta = null;
                 }
             }
         }
 
-        this.alpha = MathHelper.clamp(this.alpha, 0f, this.properties.getMaxAlpha());
+        this.alpha = MathHelper.clamp(this.alpha, 0F, this.properties.getMaxAlpha());
 
         return this.alpha;
     }
@@ -321,11 +322,11 @@ public abstract class AbstractSkybox implements FSBSkybox {
 
     @Override
     public boolean isActive() {
-        return this.getAlpha() > SkyboxManager.MINIMUM_ALPHA;
+        return this.getAlpha() > Constants.MINIMUM_ALPHA;
     }
 
     @Override
     public boolean isActiveLater() {
-        return this.updateAlpha() > SkyboxManager.MINIMUM_ALPHA;
+        return this.updateAlpha() > Constants.MINIMUM_ALPHA;
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -64,18 +64,30 @@ public abstract class AbstractSkybox implements FSBSkybox {
     }
 
     /**
+     * Sets {@link AbstractSkybox#calculateNextAlpha()} to skybox's alpha value.
+     *
+     * @return The skybox's alpha value.
+     */
+    @Override
+    public final float updateAlpha() {
+        this.alpha = this.calculateNextAlpha();
+
+        return this.alpha;
+    }
+
+    /**
      * Calculates the alpha value for the current time and conditions and returns it.
      *
      * @return The new alpha value.
      */
-    @Override
-    public final float updateAlpha() {
+    private float calculateNextAlpha() {
+        float alpha = this.alpha;
         int currentTime = (int) (Objects.requireNonNull(MinecraftClient.getInstance().world).getTimeOfDay() % 24000);
 
         boolean shouldRender = Utils.isInTimeInterval(currentTime, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getStartFadeOut() - 1);
 
         if ((shouldRender || this.properties.getFade().isAlwaysOn()) && checkBiomes() && checkXRanges() && checkYRanges() && checkZRanges() && checkWeather() && checkEffect() && checkLoop()) {
-            if (this.alpha < this.properties.getMaxAlpha()) {
+            if (alpha < this.properties.getMaxAlpha()) {
                 // Check if currentTime is at the beginning of fadeIn
                 if (this.properties.getFade().getStartFadeIn() == currentTime && this.fadeInDelta == null) {
                     float f1 = Utils.normalizeTime(this.properties.getMaxAlpha(), currentTime, this.properties.getFade().getStartFadeIn(), this.properties.getFade().getEndFadeIn());
@@ -83,15 +95,15 @@ public abstract class AbstractSkybox implements FSBSkybox {
                     this.fadeInDelta = f2 - f1;
                 }
 
-                this.alpha += Objects.requireNonNullElseGet(this.fadeInDelta, () -> this.properties.getMaxAlpha() / this.properties.getTransitionInDuration());
+                alpha += Objects.requireNonNullElseGet(this.fadeInDelta, () -> this.properties.getMaxAlpha() / this.properties.getTransitionInDuration());
             } else {
-                this.alpha = this.properties.getMaxAlpha();
+                alpha = this.properties.getMaxAlpha();
                 if (this.fadeInDelta != null) {
                     this.fadeInDelta = null;
                 }
             }
         } else {
-            if (this.alpha > 0f) {
+            if (alpha > 0f) {
                 // Check if currentTime is at the beginning of fadeOut
                 if (this.properties.getFade().getStartFadeOut() == currentTime && this.fadeOutDelta == null) {
                     float f1 = Utils.normalizeTime(this.properties.getMaxAlpha(), currentTime, this.properties.getFade().getStartFadeOut(), this.properties.getFade().getEndFadeOut());
@@ -99,18 +111,18 @@ public abstract class AbstractSkybox implements FSBSkybox {
                     this.fadeOutDelta = f2 - f1;
                 }
 
-                this.alpha -= Objects.requireNonNullElseGet(this.fadeOutDelta, () -> this.properties.getMaxAlpha() / this.properties.getTransitionOutDuration());
+                alpha -= Objects.requireNonNullElseGet(this.fadeOutDelta, () -> this.properties.getMaxAlpha() / this.properties.getTransitionOutDuration());
             } else {
-                this.alpha = 0F;
+                alpha = 0F;
                 if (this.fadeOutDelta != null) {
                     this.fadeOutDelta = null;
                 }
             }
         }
 
-        this.alpha = MathHelper.clamp(this.alpha, 0F, this.properties.getMaxAlpha());
+        alpha = MathHelper.clamp(alpha, 0F, this.properties.getMaxAlpha());
 
-        return this.alpha;
+        return alpha;
     }
 
     /**
@@ -327,11 +339,6 @@ public abstract class AbstractSkybox implements FSBSkybox {
 
     @Override
     public boolean isActiveLater() {
-        final float oldAlpha = this.alpha;
-        if (this.updateAlpha() > Constants.MINIMUM_ALPHA) {
-            this.alpha = oldAlpha;
-            return true;
-        }
-        return false;
+        return this.calculateNextAlpha() > Constants.MINIMUM_ALPHA;
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/LegacyDeserializer.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/LegacyDeserializer.java
@@ -31,7 +31,7 @@ public class LegacyDeserializer<T extends AbstractSkybox> {
     private static void decodeSquareTextured(JsonObjectWrapper wrapper, AbstractSkybox skybox) {
         decodeSharedData(wrapper, skybox);
         ((SquareTexturedSkybox) skybox).rotation = new Rotation(new Vector3f(0f, 0f, 0f), new Vector3f(wrapper.getOptionalArrayFloat("axis", 0, 0), wrapper.getOptionalArrayFloat("axis", 1, 0), wrapper.getOptionalArrayFloat("axis", 2, 0)), 1);
-        ((SquareTexturedSkybox) skybox).blend = new Blend(wrapper.getOptionalBoolean("shouldBlend", false) ? "add" : "", 0, 0, 0);
+        ((SquareTexturedSkybox) skybox).blend = new Blend(wrapper.getOptionalBoolean("shouldBlend", false) ? "add" : "", 0, 0, 0, false, false, false, true);
         ((SquareTexturedSkybox) skybox).textures = new Textures(
                 new Texture(wrapper.getJsonStringAsId("texture_north")),
                 new Texture(wrapper.getJsonStringAsId("texture_south")),

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/LegacyDeserializer.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/LegacyDeserializer.java
@@ -48,6 +48,7 @@ public class LegacyDeserializer<T extends AbstractSkybox> {
     }
 
     private static void decodeSharedData(JsonObjectWrapper wrapper, AbstractSkybox skybox) {
+        float maxAlpha = wrapper.getOptionalFloat("maxAlpha", 1f);
         skybox.properties = new Properties.Builder()
                 .fade(new Fade(
                         wrapper.get("startFadeIn").getAsInt(),
@@ -56,8 +57,9 @@ public class LegacyDeserializer<T extends AbstractSkybox> {
                         wrapper.get("endFadeOut").getAsInt(),
                         false
                 ))
-                .maxAlpha(wrapper.getOptionalFloat("maxAlpha", 1f))
-                .transitionSpeed(wrapper.getOptionalFloat("transitionSpeed", 1f))
+                .maxAlpha(maxAlpha)
+                .transitionInDuration((int) (maxAlpha / wrapper.getOptionalFloat("transitionSpeed", 0.05f)))
+                .transitionOutDuration((int) (maxAlpha / wrapper.getOptionalFloat("transitionSpeed", 0.05f)))
                 .shouldRotate(wrapper.getOptionalBoolean("shouldRotate", false))
                 .changeFog(wrapper.getOptionalBoolean("changeFog", false))
                 .fogColors(new RGBA(

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Constants.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Constants.java
@@ -1,0 +1,6 @@
+package io.github.amerebagatelle.fabricskyboxes.util;
+
+public class Constants {
+    public static final int MAX_FADE_DURATION = 24000 * 365;
+    public static final float MINIMUM_ALPHA = 1F / MAX_FADE_DURATION;
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
@@ -18,6 +18,30 @@ public class Utils {
         return end - start;
     }
 
+    public static boolean isWithinDuration(int currentTime, int startTime, int endTime) {
+        if (currentTime >= 24000 && currentTime < 0) {
+            throw new RuntimeException("Invalid current time, value must be between 0-23999: " + currentTime);
+        }
+        if (startTime <= endTime) {
+            return currentTime >= startTime && currentTime <= endTime;
+        } else {
+            return currentTime >= startTime || currentTime <= endTime;
+        }
+    }
+
+    public static float getPosition(float maxAlpha, int currentTime, int startTime, int endTime) {
+        if (!isWithinDuration(currentTime, startTime, endTime))
+            return 0f;
+
+        int range = (endTime - startTime + 24000) % 24000;
+        if (range == 0) {
+            return 0f;
+        }
+
+        float position = (float)((currentTime - startTime + 24000) % 24000) / range;
+        return position * maxAlpha;
+    }
+
     public static Codec<Float> getClampedFloat(float min, float max) {
         if (min > max) {
             throw new UnsupportedOperationException("Maximum value was lesser than than the minimum value");

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
@@ -42,6 +42,13 @@ public class Utils {
         return position * maxAlpha;
     }
 
+    public static Codec<Integer> getClampedInteger(int min, int max) {
+        if (min > max) {
+            throw new UnsupportedOperationException("Maximum value was lesser than than the minimum value");
+        }
+        return Codec.INT.xmap(f -> MathHelper.clamp(f, min, max), Function.identity());
+    }
+
     public static Codec<Float> getClampedFloat(float min, float max) {
         if (min > max) {
             throw new UnsupportedOperationException("Maximum value was lesser than than the minimum value");

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
@@ -18,7 +18,7 @@ public class Utils {
         return end - start;
     }
 
-    public static boolean isWithinDuration(int currentTime, int startTime, int endTime) {
+    public static boolean isInTimeInterval(int currentTime, int startTime, int endTime) {
         if (currentTime >= 24000 && currentTime < 0) {
             throw new RuntimeException("Invalid current time, value must be between 0-23999: " + currentTime);
         }
@@ -29,8 +29,8 @@ public class Utils {
         }
     }
 
-    public static float getPosition(float maxAlpha, int currentTime, int startTime, int endTime) {
-        if (!isWithinDuration(currentTime, startTime, endTime))
+    public static float normalizeTime(float maxAlpha, int currentTime, int startTime, int endTime) {
+        if (!isInTimeInterval(currentTime, startTime, endTime))
             return 0f;
 
         int range = (endTime - startTime + 24000) % 24000;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -51,12 +51,12 @@ public class Blend {
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
                 case "subtract" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
-                    RenderSystem.blendEquation(Equation.REVERSE_SUBTRACT.value);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE_MINUS_DST_COLOR, GlStateManager.DstFactor.ZERO);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "multiply" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ZERO);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
                     RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, alpha);
                 };
@@ -77,11 +77,11 @@ public class Blend {
                 };
                 case "burn" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
-                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
+                    RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "dodge" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
                     RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -11,36 +11,48 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 public class Blend {
-    public static final Blend DEFAULT = new Blend("", 0, 0, 0);
+    public static final Blend DEFAULT = new Blend("", 0, 0, 0, false, false, false, true);
     public static Codec<Blend> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.optionalFieldOf("type", "").forGetter(Blend::getType),
             Codec.INT.optionalFieldOf("sFactor", -1).forGetter(Blend::getSFactor),
             Codec.INT.optionalFieldOf("dFactor", -1).forGetter(Blend::getDFactor),
-            Codec.INT.optionalFieldOf("equation", -1).forGetter(Blend::getEquation)
+            Codec.INT.optionalFieldOf("equation", -1).forGetter(Blend::getEquation),
+            Codec.BOOL.optionalFieldOf("redAlphaEnabled", false).forGetter(Blend::isRedAlphaEnabled),
+            Codec.BOOL.optionalFieldOf("greenAlphaEnabled", false).forGetter(Blend::isGreenAlphaEnabled),
+            Codec.BOOL.optionalFieldOf("blueAlphaEnabled", false).forGetter(Blend::isBlueAlphaEnabled),
+            Codec.BOOL.optionalFieldOf("alphaEnabled", true).forGetter(Blend::isAlphaEnabled)
     ).apply(instance, Blend::new));
     private final String type;
     private final int sFactor;
     private final int dFactor;
     private final int equation;
+    private final boolean redAlphaEnabled;
+    private final boolean greenAlphaEnabled;
+    private final boolean blueAlphaEnabled;
+    private final boolean alphaEnabled;
 
     private final Consumer<Float> blendFunc;
 
-    public Blend(String type, int sFactor, int dFactor, int equation) {
+    public Blend(String type, int sFactor, int dFactor, int equation, boolean redAlphaEnabled, boolean greenAlphaEnabled, boolean blueAlphaEnabled, boolean alphaEnabled) {
         this.type = type;
         this.sFactor = sFactor;
         this.dFactor = dFactor;
         this.equation = equation;
+        this.redAlphaEnabled = redAlphaEnabled;
+        this.greenAlphaEnabled = greenAlphaEnabled;
+        this.blueAlphaEnabled = blueAlphaEnabled;
+        this.alphaEnabled = alphaEnabled;
 
         if (!type.isEmpty()) {
             switch (type) {
                 case "add" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
                     RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
                 case "subtract" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE_MINUS_DST_COLOR, GlStateManager.DstFactor.ZERO);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
+                    RenderSystem.blendEquation(Equation.REVERSE_SUBTRACT.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "multiply" -> blendFunc = (alpha) -> {
@@ -54,7 +66,7 @@ public class Blend {
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "replace" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
                     RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
@@ -65,23 +77,13 @@ public class Blend {
                 };
                 case "burn" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Equation.SUBTRACT.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "dodge" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE);
                     RenderSystem.blendEquation(Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
-                };
-                case "darken" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(Equation.MIN.value);
-                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
-                };
-                case "lighten" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(Equation.MAX.value);
-                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
                 default -> {
                     FabricSkyBoxesClient.getLogger().error("Blend mode is set to an invalid or unsupported value.");
@@ -95,7 +97,7 @@ public class Blend {
             blendFunc = (alpha) -> {
                 RenderSystem.blendFunc(sFactor, dFactor);
                 RenderSystem.blendEquation(equation);
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
+                RenderSystem.setShaderColor(redAlphaEnabled ? alpha : 1.0F, greenAlphaEnabled ? alpha : 1.0F, blueAlphaEnabled ? alpha : 1.0F, alphaEnabled ? alpha : 1.0F);
             };
         } else {
             blendFunc = (alpha) -> {
@@ -123,6 +125,22 @@ public class Blend {
 
     public int getEquation() {
         return equation;
+    }
+
+    public boolean isRedAlphaEnabled() {
+        return redAlphaEnabled;
+    }
+
+    public boolean isGreenAlphaEnabled() {
+        return greenAlphaEnabled;
+    }
+
+    public boolean isBlueAlphaEnabled() {
+        return blueAlphaEnabled;
+    }
+
+    public boolean isAlphaEnabled() {
+        return alphaEnabled;
     }
 
     public boolean isValidFactor(int factor) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Properties.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Properties.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.RotatableSkybox;
 import io.github.amerebagatelle.fabricskyboxes.skyboxes.AbstractSkybox;
+import io.github.amerebagatelle.fabricskyboxes.util.Constants;
 import io.github.amerebagatelle.fabricskyboxes.util.Utils;
 
 public class Properties {
@@ -11,7 +12,8 @@ public class Properties {
             Codec.INT.optionalFieldOf("priority", 0).forGetter(Properties::getPriority),
             Fade.CODEC.fieldOf("fade").forGetter(Properties::getFade),
             Utils.getClampedFloat(.0F, 1.0F).optionalFieldOf("maxAlpha", 1.0F).forGetter(Properties::getMaxAlpha),
-            Utils.getClampedFloat(.0F, 1.0F).optionalFieldOf("transitionSpeed", 1.0F).forGetter(Properties::getTransitionSpeed),
+            Utils.getClampedInteger(1, Constants.MAX_FADE_DURATION).optionalFieldOf("transitionInDuration", 20).forGetter(Properties::getTransitionInDuration),
+            Utils.getClampedInteger(1, Constants.MAX_FADE_DURATION).optionalFieldOf("transitionOutDuration", 20).forGetter(Properties::getTransitionOutDuration),
             Codec.BOOL.optionalFieldOf("changeFog", false).forGetter(Properties::isChangeFog),
             RGBA.CODEC.optionalFieldOf("fogColors", RGBA.DEFAULT).forGetter(Properties::getFogColors),
             Codec.BOOL.optionalFieldOf("sunSkyTint", true).forGetter(Properties::isRenderSunSkyTint),
@@ -20,12 +22,13 @@ public class Properties {
             Rotation.CODEC.optionalFieldOf("rotation", Rotation.DEFAULT).forGetter(Properties::getRotation)
     ).apply(instance, Properties::new));
 
-    public static final Properties DEFAULT = new Properties(0, Fade.DEFAULT, 1.0F, 1.0F, false, RGBA.DEFAULT, true, true, false, Rotation.DEFAULT);
+    public static final Properties DEFAULT = new Properties(0, Fade.DEFAULT, 0F, 20, 20, false, RGBA.DEFAULT, true, true, false, Rotation.DEFAULT);
 
     private final int priority;
     private final Fade fade;
     private final float maxAlpha;
-    private final float transitionSpeed;
+    private final int transitionInDuration;
+    private final int transitionOutDuration;
     private final boolean changeFog;
     private final RGBA fogColors;
     private final boolean renderSunSkyTint;
@@ -33,11 +36,12 @@ public class Properties {
     private final boolean shouldRotate;
     private final Rotation rotation;
 
-    public Properties(int priority, Fade fade, float maxAlpha, float transitionSpeed, boolean changeFog, RGBA fogColors, boolean renderSunSkyTint, boolean renderInThickFog, boolean shouldRotate, Rotation rotation) {
+    public Properties(int priority, Fade fade, float maxAlpha, int transitionInDuration, int transitionOutDuration, boolean changeFog, RGBA fogColors, boolean renderSunSkyTint, boolean renderInThickFog, boolean shouldRotate, Rotation rotation) {
         this.priority = priority;
         this.fade = fade;
         this.maxAlpha = maxAlpha;
-        this.transitionSpeed = transitionSpeed;
+        this.transitionInDuration = transitionInDuration;
+        this.transitionOutDuration = transitionOutDuration;
         this.changeFog = changeFog;
         this.fogColors = fogColors;
         this.renderSunSkyTint = renderSunSkyTint;
@@ -56,7 +60,6 @@ public class Properties {
                 .renderSunSkyTint(skybox.getProperties().isRenderSunSkyTint())
                 .shouldRotate(skybox.getProperties().isShouldRotate())
                 .fogColors(skybox.getProperties().getFogColors())
-                .transitionSpeed(skybox.getProperties().getTransitionSpeed())
                 .fade(skybox.getProperties().getFade())
                 .maxAlpha(skybox.getProperties().getMaxAlpha())
                 .rotation(rot)
@@ -75,8 +78,12 @@ public class Properties {
         return this.maxAlpha;
     }
 
-    public float getTransitionSpeed() {
-        return this.transitionSpeed;
+    public int getTransitionInDuration() {
+        return transitionInDuration;
+    }
+
+    public int getTransitionOutDuration() {
+        return transitionOutDuration;
     }
 
     public boolean isChangeFog() {
@@ -107,7 +114,8 @@ public class Properties {
         private int priority = 0;
         private Fade fade = Fade.DEFAULT;
         private float maxAlpha = 1.0F;
-        private float transitionSpeed = 1.0F;
+        private int transitionInDuration = 20;
+        private int transitionOutDuration = 20;
         private boolean changeFog = false;
         private RGBA fogColors = RGBA.DEFAULT;
         private boolean renderSunSkyTint = true;
@@ -130,8 +138,13 @@ public class Properties {
             return this;
         }
 
-        public Builder transitionSpeed(float transitionSpeed) {
-            this.transitionSpeed = transitionSpeed;
+        public Builder transitionInDuration(int transitionInDuration) {
+            this.transitionInDuration = transitionInDuration;
+            return this;
+        }
+
+        public Builder transitionOutDuration(int transitionOutDuration) {
+            this.transitionOutDuration = transitionOutDuration;
             return this;
         }
 
@@ -190,7 +203,7 @@ public class Properties {
         }
 
         public Properties build() {
-            return new Properties(this.priority, this.fade, this.maxAlpha, this.transitionSpeed, this.changeFog, this.fogColors, this.renderSunSkyTint, this.renderInTickFog, this.shouldRotate, this.rotation);
+            return new Properties(this.priority, this.fade, this.maxAlpha, this.transitionInDuration, this.transitionOutDuration, this.changeFog, this.fogColors, this.renderSunSkyTint, this.renderInTickFog, this.shouldRotate, this.rotation);
         }
     }
 }

--- a/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
+++ b/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
@@ -35,7 +35,8 @@ public class SkyboxGenerationTest {
                         )
                 )
                 .maxAlpha(0.99F)
-                .transitionSpeed(0.7F)
+                .transitionInDuration(15)
+                .transitionInDuration(15)
                 .fade(new Fade(1000, 2000, 11000, 12000, false))
                 .build();
         Conditions conditions = new Conditions.Builder()

--- a/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
+++ b/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
@@ -45,7 +45,8 @@ public class TestClientModInitializer implements ClientModInitializer {
                         )
                 )
                 .maxAlpha(0.99F)
-                .transitionSpeed(0.7F)
+                .transitionInDuration(15)
+                .transitionOutDuration(15)
                 .fade(new Fade(1000, 2000, 11000, 12000, false))
                 .build();
     }


### PR DESCRIPTION
# Refactor Summary

In this refactor, several changes have been made to improve the game's blending and transition systems. 

- Altered blend modes and removed `darken` and `lighten` blend modes, which were causing issues in the game. A custom blend equation functionality has been implemented to set the shader color with an alpha channel of `1.0F`.
- The alpha calculation has been moved from the render thread to the main thread. This will help ensure consistent transition durations, as previously, the calculation done on the render thread led to varying durations depending on FPS.
- The fade system has been improved to properly use the `transitionSpeed` property for `alwaysOn` skyboxes and to respect the `maxAlpha` value, which was previously not always being respected and set to `1.0F`.
- Finally, the `transitionSpeed` property has been removed in favor of `transitionInDuration` and `transitionOutDuration`, which now take the duration in ticks instead.

# Breaking Changes
Please be aware that these changes will break resource packs that have used the `transitionSpeed` property. The default fade transition speed has been set to 20 ticks (1 second) for such resource packs that now use `transitionInDuration` and `transitionOutDuration`. The change also breaks resource packs that used the blend modes `darken` and `lighten`.

# Motivation
The motivation behind these changes is to improve the precision of transition durations and to resolve issues with blending and transition systems in the game. By using `transitionInDuration` and `transitionOutDuration`, more control can be exercised over the transition durations. Additionally, moving the alpha calculation to the main thread and improving the fade system will help ensure that transitions occur consistently and properly respect the `maxAlpha` value.