### PR TITLE
Improve decorations, custom blending & Add vanilla skyboxes

### DIFF
--- a/docs/blend.md
+++ b/docs/blend.md
@@ -37,8 +37,8 @@ This corresponds to the following OpenGL code:
 
 ```java
 glBlendFunc(ZERO,ONE_MINUS_SRC_COLOR);
-        glBlendEquation(ADD);
-        setShaderColor(RED,GREEN,BLUE,ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
+glBlendEquation(ADD);
+setShaderColor(RED,GREEN,BLUE,ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
 ```
 
 Note that unlike in normal OpenGL, FabricSkyboxes does not support enums. You must specify an integer value.
@@ -64,8 +64,8 @@ This corresponds to the following OpenGL code:
 
 ```java
 glBlendFuncSeparate(SRC_ALPHA,ONE,ONE,ZERO);
-        glBlendEquation(ADD);
-        setShaderColor(RED,GREEN,BLUE,ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
+glBlendEquation(ADD);
+setShaderColor(RED,GREEN,BLUE,ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
 ```
 
 ### Source/Destination Factor

--- a/docs/blend.md
+++ b/docs/blend.md
@@ -1,17 +1,31 @@
-# Blend Mode
-The mod uses [glBlendFunc](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml) and [glBlendEquation](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml) to blend the textured sky boxes. To get a better understanding of the blending functions and equations, you can use an [Online Visualize Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php).
+# Blend Mode Custom Blender
 
-In FabricSkyboxes, you must specify an integer value for `sFactor`, `dFactor`, and `equation`, corresponding to the `sourceFactor` and `destinationFactor` from `glBlendFunc`, and `equation` from `glBlendEquation`, respectively. A table of supported enums and their corresponding integer values is provided below.
+The mod
+uses [glBlendFunc](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFunc.xhtml)/[glBlendFuncSeparate](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFuncSeparate.xhtml)
+and [glBlendEquation](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml) to blend the
+textured sky boxes. To get a better understanding of the blending functions and equations, you can use
+an [Online Visualize Blending Tool](https://www.andersriggelsen.dk/glblendfunc.php).
+
+In FabricSkyboxes, you must specify an integer value corresponding to the `sourceFactor` and `destinationFactor`
+from `glBlendFunc`, and `equation` from `glBlendEquation`, respectively. A table of supported enums and their
+corresponding integer values is provided below.
+If `separateFunction` is enabled, you must also fill `sourceFactorAlpha` and `destinationFactorAlpha`
+from `glBlendFuncSeparate`.
 
 Here's an example of how to achieve the burn blend effect in FabricSkyboxes:
 
 #### Burn Blend Mode
+
 In the `"blend"` property of FabricSkyboxes, specify the following JSON:
+
 ```json
 {
-  "sFactor": 0,
-  "dFactor": 769,
+  "separateFunction": false,
+  "sourceFactor": 0,
+  "destinationFactor": 769,
   "equation": 32774,
+  "sourceFactorAlpha": 0,
+  "destinationFactorAlpha": 0,
   "redAlphaEnabled": true,
   "greenAlphaEnabled": true,
   "blueAlphaEnabled": true,
@@ -20,15 +34,42 @@ In the `"blend"` property of FabricSkyboxes, specify the following JSON:
 ```
 
 This corresponds to the following OpenGL code:
+
 ```java
-glBlendFunc(ZERO, ONE_MINUS_SRC_COLOR);
-glBlendEquation(ADD);
-setShaderColor(RED, GREEN, BLUE, ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
+glBlendFunc(ZERO,ONE_MINUS_SRC_COLOR);
+        glBlendEquation(ADD);
+        setShaderColor(RED,GREEN,BLUE,ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
 ```
+
 Note that unlike in normal OpenGL, FabricSkyboxes does not support enums. You must specify an integer value.
 
+#### Example decorations blender
+
+```json
+{
+  "separateFunction": true,
+  "sourceFactor": 770,
+  "destinationFactor": 1,
+  "equation": 32774,
+  "sourceFactorAlpha": 1,
+  "destinationFactorAlpha": 0,
+  "redAlphaEnabled": false,
+  "greenAlphaEnabled": false,
+  "blueAlphaEnabled": false,
+  "alphaEnabled": true
+}
+```
+
+This corresponds to the following OpenGL code:
+
+```java
+glBlendFuncSeparate(SRC_ALPHA,ONE,ONE,ZERO);
+        glBlendEquation(ADD);
+        setShaderColor(RED,GREEN,BLUE,ALPHA);  // The `redAlphaEnabled`, `greenAlphaEnabled`, `blueAlphaEnabled`, and `alphaEnabled` values will determine whether the internal alpha state or a predetermined value of 1.0 will be used for the corresponding parameters.
+```
 
 ### Source/Destination Factor
+
 | Parameter                  | Value |
 |----------------------------|-------|
 | `CONSTANT_ALPHA`           | 32771 |
@@ -48,6 +89,7 @@ Note that unlike in normal OpenGL, FabricSkyboxes does not support enums. You mu
 | `ZERO`                     | 0     |
 
 ### Equation
+
 | Parameter          | Value |
 |--------------------|-------|
 | `ADD`              | 32774 |

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -469,9 +469,9 @@ The Default value stores the overworld sun and moon textures and sets all enable
 |:-----------:|:-----------------------------------:|:-----------------------------------------------------------------------:|:--------:|:-----------------------------------------------------------------------:|
 |    `sun`    |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the sun  |   :x:    |     Default sun texture (`minecraft:textures/environment/sun.png`)      |
 |   `moon`    |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the moon |   :x:    | Default moon texture (`minecraft:textures/environment/moon_phases.png`) |
-|  `showSun`  |               Boolean               |              Specifies whether the sun should be rendered               |   :x:    |                                 `true`                                  |
-| `showMoon`  |               Boolean               |              Specifies whether the moon should be rendered              |   :x:    |                                 `true`                                  |
-| `showStars` |               Boolean               |               Specifies whether stars should be rendered                |   :x:    |                                 `true`                                  |
+|  `showSun`  |               Boolean               |              Specifies whether the sun should be rendered               |   :x:    |                                 `false`                                 |
+| `showMoon`  |               Boolean               |              Specifies whether the moon should be rendered              |   :x:    |                                 `false`                                 |
+| `showStars` |               Boolean               |               Specifies whether stars should be rendered                |   :x:    |                                 `false`                                 |
 | `rotation`  | [Rotation Object](#rotation-object) |               Specifies the rotation of the decorations.                |   :x:    |              [0,0,0] for static/axis, 1 for rotationSpeed               |
 
 **Example**

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -82,8 +82,6 @@ The basic structure of a fabricskyboxes skybox file may look something like this
     /* sun texture path (string, optional) */
     "moon": "",
     /* moon texture path (string, optional) */
-    "showVanillaSky": true,
-    /* render vanilla sky (bool, optional) */
     "showSun": true,
     /* render sun (bool, optional) */
     "showMoon": true,
@@ -512,7 +510,6 @@ The Default value stores the overworld sun and moon textures and sets all enable
 |:----------------:|:-----------------------------------:|:-----------------------------------------------------------------------:|:--------:|:-----------------------------------------------------------------------:|
 |      `sun`       |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the sun  |   :x:    |     Default sun texture (`minecraft:textures/environment/sun.png`)      |
 |      `moon`      |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the moon |   :x:    | Default moon texture (`minecraft:textures/environment/moon_phases.png`) |
-| `showVanillaSky` |               Boolean               |          Specifies whether the vanilla sky should be rendered           |   :x:    |                                 `false`                                 |
 |    `showSun`     |               Boolean               |              Specifies whether the sun should be rendered               |   :x:    |                                 `false`                                 |
 |    `showMoon`    |               Boolean               |              Specifies whether the moon should be rendered              |   :x:    |                                 `false`                                 |
 |   `showStars`    |               Boolean               |               Specifies whether stars should be rendered                |   :x:    |                                 `false`                                 |
@@ -525,7 +522,6 @@ The Default value stores the overworld sun and moon textures and sets all enable
 {
   "sun": "minecraft:textures/environment/sun.png",
   "moon": "minecraft:textures/atlas/blocks.png",
-  "showVanillaSky": false,
   "showSun": true,
   "showMoon": true,
   "showStars": false,
@@ -895,7 +891,6 @@ Here is a full skybox file for example purposes:
   "decorations": {
     "sun": "minecraft:textures/environment/sun.png",
     "moon": "minecraft:textures/environment/moon.png",
-    "showVanillaSky": true,
     "showSun": true,
     "showMoon": true,
     "showStars": true,

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -14,6 +14,8 @@ This specification defines a format for a set of rules for the purpose of custom
     - [Types](#types)
     - [Shared Data](#shared-data)
     - [`monocolor`](#mono-color-skybox)
+    - [`overworld`](#overworld-skybox)
+    - [`end`](#end-skybox)
     - [Textured](#textured-skyboxes)
     - [`square-textured`](#square-textured-skybox)
     - [`single-sprite-square-textured`](#single-sprite-square-textured-skybox)
@@ -304,6 +306,14 @@ Only the `monocolor` skybox type uses these fields
 |  Name   |          Datatype           |            Description            | Required |  Default value   |
 |:-------:|:---------------------------:|:---------------------------------:|:--------:|:----------------:|
 | `color` | [RGBA Object](#rgba-object) | Specifies the color of the skybox |   :x:    | 0 for each value |
+
+### Overworld skybox
+
+Uses fields from shared data, renders vanilla's overworld skybox.
+
+### End skybox
+
+Uses fields from shared data, renders vanilla's end skybox.
 
 ### Textured skyboxes
 
@@ -767,11 +777,11 @@ Specifies a custom blender.
 |           Name           | Datatype |                                                                                                                  Description                                                                                                                  | Required | Default value |
 |:------------------------:|:--------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:--------:|:--------------|
 |    `separateFunction`    | Boolean  | Specifies the whether OpenGL `blendFuncSeparate` will be used instead of `blendFunc`. When enabled `sourceFactor` and `destinationFactor` will be RGB channels and alpha channel is separate to `sourceFactorAlpha`/`destinationFactorAlpha`. |   :x:    | false         |
-|      `sourceFactor`      | Integer  |                                                                                                  Specifies the OpenGL source factor to use.                                                                                                   |   :x:    | -1            |
-|   `destinationFactor`    | Integer  |                                                                                                Specifies the OpenGL destination factor to use.                                                                                                |   :x:    | -1            |
-|        `equation`        | Integer  |                                                                                                  Specifies the OpenGL blend equation to use.                                                                                                  |   :x:    | -1            |
-|   `sourceFactorAlpha`    | Integer  |                                                                       Specifies the OpenGL source factor to use for alpha channel. Requires `separateFunction` enabled.                                                                       |   :x:    | -1            |
-| `destinationFactorAlpha` | Integer  |                                                                    Specifies the OpenGL destination factor to use for alpha channel. Requires `separateFunction` enabled.                                                                     |   :x:    | -1            |
+|      `sourceFactor`      | Integer  |                                                                                                  Specifies the OpenGL source factor to use.                                                                                                   |   :x:    | 770           |
+|   `destinationFactor`    | Integer  |                                                                                                Specifies the OpenGL destination factor to use.                                                                                                |   :x:    | 1             |
+|        `equation`        | Integer  |                                                                                                  Specifies the OpenGL blend equation to use.                                                                                                  |   :x:    | 32774         |
+|   `sourceFactorAlpha`    | Integer  |                                                                       Specifies the OpenGL source factor to use for alpha channel. Requires `separateFunction` enabled.                                                                       |   :x:    | 0             |
+| `destinationFactorAlpha` | Integer  |                                                                    Specifies the OpenGL destination factor to use for alpha channel. Requires `separateFunction` enabled.                                                                     |   :x:    | 0             |
 |    `redAlphaEnabled`     | Boolean  |                                                                        Specifies whether alpha state will be used in red shader color or predetermined value of `1.0`.                                                                        |   :x:    | false         |
 |   `greenAlphaEnabled`    | Boolean  |                                                                       Specifies whether alpha state will be used in green shader color or predetermined value of `1.0`.                                                                       |   :x:    | false         |
 |    `blueAlphaEnabled`    | Boolean  |                                                                       Specifies whether alpha state will be used in blue shader color or predetermined value of `1.0`.                                                                        |   :x:    | false         |

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -80,6 +80,8 @@ The basic structure of a fabricskyboxes skybox file may look something like this
     /* sun texture path (string, optional) */
     "moon": "",
     /* moon texture path (string, optional) */
+    "showVanillaSky": true,
+    /* render vanilla sky (bool, optional) */
     "showSun": true,
     /* render sun (bool, optional) */
     "showMoon": true,
@@ -496,15 +498,16 @@ The Default value stores the overworld sun and moon textures and sets all enable
 
 **Specification**
 
-|    Name     |              Datatype               |                               Description                               | Required |                              Default value                              |
-|:-----------:|:-----------------------------------:|:-----------------------------------------------------------------------:|:--------:|:-----------------------------------------------------------------------:|
-|    `sun`    |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the sun  |   :x:    |     Default sun texture (`minecraft:textures/environment/sun.png`)      |
-|   `moon`    |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the moon |   :x:    | Default moon texture (`minecraft:textures/environment/moon_phases.png`) |
-|  `showSun`  |               Boolean               |              Specifies whether the sun should be rendered               |   :x:    |                                 `false`                                 |
-| `showMoon`  |               Boolean               |              Specifies whether the moon should be rendered              |   :x:    |                                 `false`                                 |
-| `showStars` |               Boolean               |               Specifies whether stars should be rendered                |   :x:    |                                 `false`                                 |
-| `rotation`  | [Rotation Object](#rotation-object) |               Specifies the rotation of the decorations.                |   :x:    |              [0,0,0] for static/axis, 1 for rotationSpeed               |
-|   `blend`   |    [Blend Object](#blend-object)    |              Specifies the blend mode for the decorations.              |   :x:    |                  `type` and `blender` of `decorations`                  |
+|       Name       |              Datatype               |                               Description                               | Required |                              Default value                              |
+|:----------------:|:-----------------------------------:|:-----------------------------------------------------------------------:|:--------:|:-----------------------------------------------------------------------:|
+|      `sun`       |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the sun  |   :x:    |     Default sun texture (`minecraft:textures/environment/sun.png`)      |
+|      `moon`      |   [Namespaced Id](#namespaced-id)   | Specifies the location of the texture to be used for rendering the moon |   :x:    | Default moon texture (`minecraft:textures/environment/moon_phases.png`) |
+| `showVanillaSky` |               Boolean               |          Specifies whether the vanilla sky should be rendered           |   :x:    |                                 `false`                                 |
+|    `showSun`     |               Boolean               |              Specifies whether the sun should be rendered               |   :x:    |                                 `false`                                 |
+|    `showMoon`    |               Boolean               |              Specifies whether the moon should be rendered              |   :x:    |                                 `false`                                 |
+|   `showStars`    |               Boolean               |               Specifies whether stars should be rendered                |   :x:    |                                 `false`                                 |
+|    `rotation`    | [Rotation Object](#rotation-object) |               Specifies the rotation of the decorations.                |   :x:    |              [0,0,0] for static/axis, 1 for rotationSpeed               |
+|     `blend`      |    [Blend Object](#blend-object)    |              Specifies the blend mode for the decorations.              |   :x:    |                  `type` and `blender` of `decorations`                  |
 
 **Example**
 
@@ -512,6 +515,7 @@ The Default value stores the overworld sun and moon textures and sets all enable
 {
   "sun": "minecraft:textures/environment/sun.png",
   "moon": "minecraft:textures/atlas/blocks.png",
+  "showVanillaSky": false,
   "showSun": true,
   "showMoon": true,
   "showStars": false,
@@ -881,6 +885,7 @@ Here is a full skybox file for example purposes:
   "decorations": {
     "sun": "minecraft:textures/environment/sun.png",
     "moon": "minecraft:textures/environment/moon.png",
+    "showVanillaSky": true,
     "showSun": true,
     "showMoon": true,
     "showStars": true,

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -33,6 +33,7 @@ This specification defines a format for a set of rules for the purpose of custom
     - [Namespaced Id](#namespaced-id)
     - [Textures Object](#textures-object)
     - [Blend Object](#blend-object)
+    - [Blender Object](#blender-object)
     - [Loop Object](#loop-object)
 - [Full Example](#full-example)
 
@@ -94,6 +95,32 @@ The basic structure of a fabricskyboxes skybox file may look something like this
       /* axis rotation in degrees (Float Vector, optional) */
       "rotationSpeed": 0
       /* speed of rotation (float, optional) */
+    },
+    "blend": // blend object (textured types only, optional)
+    {
+      "type": "",
+      /* blend type (string, optional) */
+      "blender": {
+        // blender objects (optional) requires "type" to be "custom"
+        "sourceFactor": 0,
+        /* sFactor number (int, optional) */
+        "destinationFactor": 0,
+        /* dFactor number (int, optional) */
+        "equation": 0,
+        /* equation number (int, optional) */
+        "sourceFactorAlpha": 0,
+        /* sFactor alpha number (int, optional) */
+        "destinationFactorAlpha": 0,
+        /* dFactor alpha number (int, optional) */
+        "redAlphaEnabled": false,
+        /* red alpha state (boolean, optional) */
+        "greenAlphaEnabled": false,
+        /* green alpha state (boolean, optional) */
+        "blueAlphaEnabled": false,
+        /* blue alpha state (boolean, optional) */
+        "alphaEnabled": true
+        /* alpha state (boolean, optional) */
+      }
     }
   },
   "properties": // default properties object
@@ -165,23 +192,27 @@ The basic structure of a fabricskyboxes skybox file may look something like this
   {
     "type": "",
     /* blend type (string, optional) */
-
-    // OR
-
-    "sFactor": 0,
-    /* sFactor number (int, optional) */
-    "dFactor": 0,
-    /* dFactor number (int, optional) */
-    "equation": 0,
-    /* equation number (int, optional) */
-    "redAlphaEnabled": false,
-    /* red alpha state (boolean, optional) */
-    "greenAlphaEnabled": false,
-    /* green alpha state (boolean, optional) */
-    "blueAlphaEnabled": false,
-    /* blue alpha state (boolean, optional) */
-    "alphaEnabled": true
-    /* alpha state (boolean, optional) */
+    "blender": {
+      // blender objects (optional) requires "type" to be "custom"
+      "sourceFactor": 0,
+      /* sFactor number (int, optional) */
+      "destinationFactor": 0,
+      /* dFactor number (int, optional) */
+      "equation": 0,
+      /* equation number (int, optional) */
+      "sourceFactorAlpha": 0,
+      /* sFactor alpha number (int, optional) */
+      "destinationFactorAlpha": 0,
+      /* dFactor alpha number (int, optional) */
+      "redAlphaEnabled": false,
+      /* red alpha state (boolean, optional) */
+      "greenAlphaEnabled": false,
+      /* green alpha state (boolean, optional) */
+      "blueAlphaEnabled": false,
+      /* blue alpha state (boolean, optional) */
+      "alphaEnabled": true
+      /* alpha state (boolean, optional) */
+    }
   },
   "textures": // textures object (square-textured type only)
   {
@@ -473,6 +504,7 @@ The Default value stores the overworld sun and moon textures and sets all enable
 | `showMoon`  |               Boolean               |              Specifies whether the moon should be rendered              |   :x:    |                                 `false`                                 |
 | `showStars` |               Boolean               |               Specifies whether stars should be rendered                |   :x:    |                                 `false`                                 |
 | `rotation`  | [Rotation Object](#rotation-object) |               Specifies the rotation of the decorations.                |   :x:    |              [0,0,0] for static/axis, 1 for rotationSpeed               |
+|   `blend`   |    [Blend Object](#blend-object)    |              Specifies the blend mode for the decorations.              |   :x:    |                  `type` and `blender` of `decorations`                  |
 
 **Example**
 
@@ -494,7 +526,10 @@ The Default value stores the overworld sun and moon textures and sets all enable
       108,
       72
     ],
-    "rotationSpeed": 1.0
+    "rotationSpeed": 1.0,
+    "blend": {
+      "type": "decorations"
+    }
   }
 }
 ```
@@ -681,18 +716,13 @@ Specifies the blend type or equation.
 
 **Specification**
 
-|        Name         | Datatype |                                            Description                                            | Required | Default value |
-|:-------------------:|:--------:|:-------------------------------------------------------------------------------------------------:|:--------:|:--------------|
-|       `type`        |  String  |                                 Specifies the type of the blend.                                  |   :x:    |               |
-|      `sFactor`      | Integer  |                            Specifies the OpenGL source factor to use.                             |   :x:    |               |
-|      `dFactor`      | Integer  |                          Specifies the OpenGL destination factor to use.                          |   :x:    |               |
-|     `equation`      | Integer  |                            Specifies the OpenGL blend equation to use.                            |   :x:    |               |
-|  `redAlphaEnabled`  | Boolean  |  Specifies whether alpha state will be used in red shader color or predetermined value of `1.0`.  |   :x:    | false         |
-| `greenAlphaEnabled` | Boolean  | Specifies whether alpha state will be used in green shader color or predetermined value of `1.0`. |   :x:    | false         |
-| `blueAlphaEnabled`  | Boolean  | Specifies whether alpha state will be used in blue shader color or predetermined value of `1.0`.  |   :x:    | false         |
-|   `alphaEnabled`    | Boolean  |    Specifies whether alpha state will be used in shader color or predetermined value of `1.0`.    |   :x:    | true          |
+|   Name    |             Datatype              |                                       Description                                        | Required | Default value |
+|:---------:|:---------------------------------:|:----------------------------------------------------------------------------------------:|:--------:|:--------------|
+|  `type`   |              String               |                             Specifies the type of the blend.                             |   :x:    |               |
+| `blender` | [Blender Object](#blender-object) | Specifies the custom blender function to be used. Requires `type` to be set to `custom`. |   :x:    |               |
 
-Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha`, `dodge`, `burn`, `darken` and `lighten`.
+Valid types are: `add`, `subtract`, `multiply`, `screen`, `replace`, `alpha`, `dodge`, `burn`, `decorations`, `disable`
+and `custom`.
 
 More information on custom blend can be found in the [blend documentation](blend.md).
 
@@ -708,9 +738,53 @@ More information on custom blend can be found in the [blend documentation](blend
 
 ```json
 {
-  "sFactor": 0,
-  "dFactor": 0,
+  "type": "custom",
+  "blender": {
+    "separateFunction": false,
+    "sourceFactor": 0,
+    "destinationFactor": 0,
+    "equation": 0,
+    "sourceFactorAlpha": 0,
+    "destinationFactorAlpha": 0,
+    "redAlphaEnabled": true,
+    "greenAlphaEnabled": true,
+    "blueAlphaEnabled": true,
+    "alphaEnabled": false
+  }
+}
+```
+
+### Blender Object
+
+Specifies a custom blender.
+
+**Specification**
+
+|           Name           | Datatype |                                                                                                                  Description                                                                                                                  | Required | Default value |
+|:------------------------:|:--------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:--------:|:--------------|
+|    `separateFunction`    | Boolean  | Specifies the whether OpenGL `blendFuncSeparate` will be used instead of `blendFunc`. When enabled `sourceFactor` and `destinationFactor` will be RGB channels and alpha channel is separate to `sourceFactorAlpha`/`destinationFactorAlpha`. |   :x:    | false         |
+|      `sourceFactor`      | Integer  |                                                                                                  Specifies the OpenGL source factor to use.                                                                                                   |   :x:    | -1            |
+|   `destinationFactor`    | Integer  |                                                                                                Specifies the OpenGL destination factor to use.                                                                                                |   :x:    | -1            |
+|        `equation`        | Integer  |                                                                                                  Specifies the OpenGL blend equation to use.                                                                                                  |   :x:    | -1            |
+|   `sourceFactorAlpha`    | Integer  |                                                                       Specifies the OpenGL source factor to use for alpha channel. Requires `separateFunction` enabled.                                                                       |   :x:    | -1            |
+| `destinationFactorAlpha` | Integer  |                                                                    Specifies the OpenGL destination factor to use for alpha channel. Requires `separateFunction` enabled.                                                                     |   :x:    | -1            |
+|    `redAlphaEnabled`     | Boolean  |                                                                        Specifies whether alpha state will be used in red shader color or predetermined value of `1.0`.                                                                        |   :x:    | false         |
+|   `greenAlphaEnabled`    | Boolean  |                                                                       Specifies whether alpha state will be used in green shader color or predetermined value of `1.0`.                                                                       |   :x:    | false         |
+|    `blueAlphaEnabled`    | Boolean  |                                                                       Specifies whether alpha state will be used in blue shader color or predetermined value of `1.0`.                                                                        |   :x:    | false         |
+|      `alphaEnabled`      | Boolean  |                                                                          Specifies whether alpha state will be used in shader color or predetermined value of `1.0`.                                                                          |   :x:    | true          |
+
+More information on custom blend can be found in the [blend documentation](blend.md).
+
+**Example**
+
+```json
+{
+  "separateFunction": false,
+  "sourceFactor": 0,
+  "destinationFactor": 0,
   "equation": 0,
+  "sourceFactorAlpha": 0,
+  "destinationFactorAlpha": 0,
   "redAlphaEnabled": true,
   "greenAlphaEnabled": true,
   "blueAlphaEnabled": true,
@@ -822,6 +896,9 @@ Here is a full skybox file for example purposes:
         0
       ],
       "rotationSpeed": 1.0
+    },
+    "blend": {
+      "type": "decorations"
     }
   },
   "blend": {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/FabricSkyBoxesClient.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/FabricSkyBoxesClient.java
@@ -34,7 +34,7 @@ public class FabricSkyBoxesClient implements ClientModInitializer {
         SkyboxType.initRegistry();
         toggleFabricSkyBoxes = KeyBindingHelper.registerKeyBinding(new KeyBinding("key.fabricskyboxes.toggle", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_KP_0, "category.fabricskyboxes"));
         ResourceManagerHelper.get(ResourceType.CLIENT_RESOURCES).registerReloadListener(new SkyboxResourceListener());
-        ClientTickEvents.END_CLIENT_TICK.register(SkyboxManager.getInstance());
+        ClientTickEvents.END_WORLD_TICK.register(SkyboxManager.getInstance());
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (toggleFabricSkyBoxes.wasPressed()) {
                 SkyboxManager.getInstance().setEnabled(!SkyboxManager.getInstance().isEnabled());

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -142,8 +142,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
         // Add the skyboxes to a activeSkyboxes container so that they can be ordered
         this.skyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
         this.permanentSkyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
-        // whether we should render the decorations, makes sure we don't get two suns
-        this.resetDecorationsState();
         // Let's not sort by alpha value
         //this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Float.compare(fsbSkybox1.getAlpha(), fsbSkybox2.getAlpha()) /*fsbSkybox1.getAlpha() >= fsbSkybox2.getAlpha() ? 0 : 1*/ : 0);
         this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Integer.compare(fsbSkybox1.getPriority(), fsbSkybox2.getPriority()): 0);
@@ -151,43 +149,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
             this.currentSkybox = skybox;
             skybox.render(worldRendererAccess, matrices, matrix4f, tickDelta, camera, thickFog);
         });
-    }
-
-    @Internal
-    public void resetDecorationsState() {
-        this.sunRendered = false;
-        this.moonRendered = false;
-        this.starsRendered = false;
-    }
-
-    @Internal
-    public boolean hasRenderedSun() {
-        if (this.sunRendered) {
-            return true;
-        } else {
-            this.sunRendered = true;
-            return false;
-        }
-    }
-
-    @Internal
-    public boolean hasRenderedMoon() {
-        if (this.moonRendered) {
-            return true;
-        } else {
-            this.moonRendered = true;
-            return false;
-        }
-    }
-
-    @Internal
-    public boolean hasRenderedStars() {
-        if (this.starsRendered) {
-            return true;
-        } else {
-            this.starsRendered = true;
-            return false;
-        }
     }
 
     public boolean isEnabled() {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -44,10 +44,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
     private boolean enabled = true;
     private float totalAlpha = 0f;
 
-    private boolean sunRendered;
-    private boolean moonRendered;
-    private boolean starsRendered;
-
     public static AbstractSkybox parseSkyboxJson(Identifier id, JsonObjectWrapper objectWrapper) {
         AbstractSkybox skybox;
         Metadata metadata;
@@ -166,6 +162,11 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
     @Override
     public int getApiVersion() {
         return 0;
+    }
+
+    @Override
+    public List<Skybox> getActiveSkyboxes() {
+        return this.activeSkyboxes;
     }
 
     @Override

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -14,9 +14,9 @@ import io.github.amerebagatelle.fabricskyboxes.util.JsonObjectWrapper;
 import io.github.amerebagatelle.fabricskyboxes.util.object.internal.Metadata;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.joml.Matrix4f;
@@ -29,7 +29,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTick {
+public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndWorldTick {
     private static final SkyboxManager INSTANCE = new SkyboxManager();
     private final Map<Identifier, Skybox> skyboxMap = new Object2ObjectLinkedOpenHashMap<>();
     /**
@@ -135,9 +135,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
 
     @Internal
     public void renderSkyboxes(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
-        // Let's not sort by alpha value
-        //this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Float.compare(fsbSkybox1.getAlpha(), fsbSkybox2.getAlpha()) /*fsbSkybox1.getAlpha() >= fsbSkybox2.getAlpha() ? 0 : 1*/ : 0);
-        this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Integer.compare(fsbSkybox1.getPriority(), fsbSkybox2.getPriority()): 0);
         this.activeSkyboxes.forEach(skybox -> {
             this.currentSkybox = skybox;
             skybox.render(worldRendererAccess, matrices, matrix4f, tickDelta, camera, thickFog);
@@ -167,13 +164,14 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
     }
 
     @Override
-    public void onEndTick(MinecraftClient client) {
-        if (MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().isPaused())
-            return;
-
+    public void onEndTick(ClientWorld world) {
         // Add the skyboxes to a activeSkyboxes container so that they can be ordered
         this.skyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
         this.permanentSkyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
+
+        // Let's not sort by alpha value
+        //this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Float.compare(fsbSkybox1.getAlpha(), fsbSkybox2.getAlpha()) : 0);
+        this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Integer.compare(fsbSkybox1.getPriority(), fsbSkybox2.getPriority()) : 0);
 
         this.totalAlpha = (float) StreamSupport
                 .stream(Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values()).spliterator(), false)

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -42,8 +42,11 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
     private final Predicate<? super Skybox> renderPredicate = (skybox) -> !this.activeSkyboxes.contains(skybox) && skybox.isActive();
     private Skybox currentSkybox = null;
     private boolean enabled = true;
-    private boolean decorationsRendered;
     private float totalAlpha = 0f;
+
+    private boolean sunRendered;
+    private boolean moonRendered;
+    private boolean starsRendered;
 
     public static AbstractSkybox parseSkyboxJson(Identifier id, JsonObjectWrapper objectWrapper) {
         AbstractSkybox skybox;
@@ -140,7 +143,7 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
         this.skyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
         this.permanentSkyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
         // whether we should render the decorations, makes sure we don't get two suns
-        this.decorationsRendered = false;
+        this.resetDecorationsState();
         // Let's not sort by alpha value
         //this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Float.compare(fsbSkybox1.getAlpha(), fsbSkybox2.getAlpha()) /*fsbSkybox1.getAlpha() >= fsbSkybox2.getAlpha() ? 0 : 1*/ : 0);
         this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Integer.compare(fsbSkybox1.getPriority(), fsbSkybox2.getPriority()): 0);
@@ -151,11 +154,38 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
     }
 
     @Internal
-    public boolean hasRenderedDecorations() {
-        if (this.decorationsRendered) {
+    public void resetDecorationsState() {
+        this.sunRendered = false;
+        this.moonRendered = false;
+        this.starsRendered = false;
+    }
+
+    @Internal
+    public boolean hasRenderedSun() {
+        if (this.sunRendered) {
             return true;
         } else {
-            this.decorationsRendered = true;
+            this.sunRendered = true;
+            return false;
+        }
+    }
+
+    @Internal
+    public boolean hasRenderedMoon() {
+        if (this.moonRendered) {
+            return true;
+        } else {
+            this.moonRendered = true;
+            return false;
+        }
+    }
+
+    @Internal
+    public boolean hasRenderedStars() {
+        if (this.starsRendered) {
+            return true;
+        } else {
+            this.starsRendered = true;
             return false;
         }
     }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -135,9 +135,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
 
     @Internal
     public void renderSkyboxes(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
-        // Add the skyboxes to a activeSkyboxes container so that they can be ordered
-        this.skyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
-        this.permanentSkyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
         // Let's not sort by alpha value
         //this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Float.compare(fsbSkybox1.getAlpha(), fsbSkybox2.getAlpha()) /*fsbSkybox1.getAlpha() >= fsbSkybox2.getAlpha() ? 0 : 1*/ : 0);
         this.activeSkyboxes.sort((skybox1, skybox2) -> skybox1 instanceof FSBSkybox fsbSkybox1 && skybox2 instanceof FSBSkybox fsbSkybox2 ? Integer.compare(fsbSkybox1.getPriority(), fsbSkybox2.getPriority()): 0);
@@ -173,6 +170,10 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndTic
     public void onEndTick(MinecraftClient client) {
         if (MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().isPaused())
             return;
+
+        // Add the skyboxes to a activeSkyboxes container so that they can be ordered
+        this.skyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
+        this.permanentSkyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);
 
         this.totalAlpha = (float) StreamSupport
                 .stream(Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values()).spliterator(), false)

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/api/FabricSkyBoxesApi.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/api/FabricSkyBoxesApi.java
@@ -6,6 +6,8 @@ import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.Skybox;
 import io.github.amerebagatelle.fabricskyboxes.util.JsonObjectWrapper;
 import net.minecraft.util.Identifier;
 
+import java.util.List;
+
 public interface FabricSkyBoxesApi {
 
     /**
@@ -75,4 +77,10 @@ public interface FabricSkyBoxesApi {
      * @return Current skybox being render, returns null of nothing is being rendered.
      */
     Skybox getCurrentSkybox();
+
+    /**
+     * Gets a list of active skyboxes.
+     * @return Current list of active skyboxes.
+     */
+    List<Skybox> getActiveSkyboxes();
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/api/FabricSkyBoxesApi.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/api/FabricSkyBoxesApi.java
@@ -80,6 +80,7 @@ public interface FabricSkyBoxesApi {
 
     /**
      * Gets a list of active skyboxes.
+     *
      * @return Current list of active skyboxes.
      */
     List<Skybox> getActiveSkyboxes();

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/BackgroundRendererMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/BackgroundRendererMixin.java
@@ -1,7 +1,7 @@
 package io.github.amerebagatelle.fabricskyboxes.mixin.skybox;
 
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
-import net.minecraft.client.MinecraftClient;
+import io.github.amerebagatelle.fabricskyboxes.skyboxes.OverworldSkybox;
 import net.minecraft.client.render.BackgroundRenderer;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.MathHelper;
@@ -9,27 +9,21 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import java.util.Objects;
-
 @Mixin(BackgroundRenderer.class)
 public class BackgroundRendererMixin {
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;getSkyAngle(F)F"))
     private static float fsb$redirectSkyAngle(ClientWorld instance, float v) {
-        if (SkyboxManager.getInstance().isEnabled() && !SkyboxManager.getInstance().getActiveSkyboxes().isEmpty()) {
-            Objects.requireNonNull(MinecraftClient.getInstance().world);
-            float skyAngleModified = MathHelper.floorMod(MinecraftClient.getInstance().world.getTimeOfDay() / 24000F + 0.75F, 1);
-            return skyAngleModified;
+        if (SkyboxManager.getInstance().isEnabled() && SkyboxManager.getInstance().getActiveSkyboxes().stream().anyMatch(skybox -> skybox instanceof OverworldSkybox)) {
+            return MathHelper.floorMod(instance.getTimeOfDay() / 24000F + 0.75F, 1);
         }
         return instance.getSkyAngle(v);
     }
 
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;getSkyAngleRadians(F)F"))
     private static float fsb$redirectSkyAngleRadian(ClientWorld instance, float v) {
-        if (SkyboxManager.getInstance().isEnabled() && !SkyboxManager.getInstance().getActiveSkyboxes().isEmpty()) {
-            Objects.requireNonNull(MinecraftClient.getInstance().world);
-            float skyAngle = MathHelper.floorMod(MinecraftClient.getInstance().world.getTimeOfDay() / 24000F + 0.75F, 1);
-            float skyAngleRadian = skyAngle * (float) (Math.PI * 2);
-            return skyAngleRadian;
+        if (SkyboxManager.getInstance().isEnabled() && SkyboxManager.getInstance().getActiveSkyboxes().stream().anyMatch(skybox -> skybox instanceof OverworldSkybox)) {
+            float skyAngle = MathHelper.floorMod(instance.getTimeOfDay() / 24000F + 0.75F, 1);
+            return skyAngle * (float) (Math.PI * 2);
         }
         return instance.getSkyAngleRadians(v);
     }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/BackgroundRendererMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/BackgroundRendererMixin.java
@@ -1,0 +1,36 @@
+package io.github.amerebagatelle.fabricskyboxes.mixin.skybox;
+
+import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.BackgroundRenderer;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Objects;
+
+@Mixin(BackgroundRenderer.class)
+public class BackgroundRendererMixin {
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;getSkyAngle(F)F"))
+    private static float fsb$redirectSkyAngle(ClientWorld instance, float v) {
+        if (SkyboxManager.getInstance().isEnabled() && !SkyboxManager.getInstance().getActiveSkyboxes().isEmpty()) {
+            Objects.requireNonNull(MinecraftClient.getInstance().world);
+            float skyAngleModified = MathHelper.floorMod(MinecraftClient.getInstance().world.getTimeOfDay() / 24000F + 0.75F, 1);
+            return skyAngleModified;
+        }
+        return instance.getSkyAngle(v);
+    }
+    
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;getSkyAngleRadians(F)F"))
+    private static float fsb$redirectSkyAngleRadian(ClientWorld instance, float v) {
+        if (SkyboxManager.getInstance().isEnabled() && !SkyboxManager.getInstance().getActiveSkyboxes().isEmpty()) {
+            Objects.requireNonNull(MinecraftClient.getInstance().world);
+            float skyAngle = MathHelper.floorMod(MinecraftClient.getInstance().world.getTimeOfDay() / 24000F + 0.75F, 1);
+            float skyAngleRadian = skyAngle * (float) (Math.PI * 2);
+            return skyAngleRadian;
+        }
+        return instance.getSkyAngleRadians(v);
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/BackgroundRendererMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/BackgroundRendererMixin.java
@@ -22,7 +22,7 @@ public class BackgroundRendererMixin {
         }
         return instance.getSkyAngle(v);
     }
-    
+
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/world/ClientWorld;getSkyAngleRadians(F)F"))
     private static float fsb$redirectSkyAngleRadian(ClientWorld instance, float v) {
         if (SkyboxManager.getInstance().isEnabled() && !SkyboxManager.getInstance().getActiveSkyboxes().isEmpty()) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
@@ -1,31 +1,132 @@
 package io.github.amerebagatelle.fabricskyboxes.mixin.skybox;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
 import io.github.amerebagatelle.fabricskyboxes.util.Constants;
-import net.minecraft.client.render.Camera;
-import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.ShaderProgram;
+import net.minecraft.client.gl.VertexBuffer;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.RotationAxis;
+import net.minecraft.util.math.Vec3d;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(WorldRenderer.class)
-public class SkyboxRenderMixin {
+public abstract class SkyboxRenderMixin {
+
     /**
      * Contains the logic for when skyboxes should be rendered.
      */
     @Inject(method = "renderSky(Lnet/minecraft/client/util/math/MatrixStack;Lorg/joml/Matrix4f;FLnet/minecraft/client/render/Camera;ZLjava/lang/Runnable;)V", at = @At("HEAD"), cancellable = true)
     private void renderCustomSkyboxes(MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean bl, Runnable runnable, CallbackInfo ci) {
         SkyboxManager skyboxManager = SkyboxManager.getInstance();
-        if (skyboxManager.isEnabled()) {
+        if (skyboxManager.isEnabled() && !skyboxManager.getActiveSkyboxes().isEmpty()) {
             runnable.run();
-            float total = skyboxManager.getTotalAlpha();
+            this.renderSky((WorldRendererAccess) this, matrices, matrix4f, tickDelta);
             skyboxManager.renderSkyboxes((WorldRendererAccess) this, matrices, matrix4f, tickDelta, camera, bl);
-            if (total > Constants.MINIMUM_ALPHA) {
-                ci.cancel();
+            ci.cancel();
+        }
+    }
+
+    // Vanilla copy of renderSky and renderEndSky with decorations stripped
+    @Unique
+    private void renderSky(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        ClientWorld world = client.world;
+        assert client.world != null;
+
+        BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
+
+        if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.END) {
+            RenderSystem.enableBlend();
+            RenderSystem.depthMask(false);
+            RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+            RenderSystem.setShaderTexture(0, WorldRendererAccess.getEndSky());
+            Tessellator tessellator = Tessellator.getInstance();
+
+            for (int i = 0; i < 6; ++i) {
+                matrices.push();
+                if (i == 1) {
+                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
+                }
+
+                if (i == 2) {
+                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90.0F));
+                }
+
+                if (i == 3) {
+                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
+                }
+
+                if (i == 4) {
+                    matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
+                }
+
+                if (i == 5) {
+                    matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
+                }
+
+                Matrix4f matrix4f = matrices.peek().getPositionMatrix();
+                bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+                bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(0.0F, 0.0F).color(40, 40, 40, 255).next();
+                bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(0.0F, 16.0F).color(40, 40, 40, 255).next();
+                bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(16.0F, 16.0F).color(40, 40, 40, 255).next();
+                bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(16.0F, 0.0F).color(40, 40, 40, 255).next();
+                tessellator.draw();
+                matrices.pop();
             }
+
+            RenderSystem.depthMask(true);
+            RenderSystem.disableBlend();
+        } else if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.NORMAL) {
+            Vec3d vec3d = world.getSkyColor(client.gameRenderer.getCamera().getPos(), tickDelta);
+            float f = (float) vec3d.x;
+            float g = (float) vec3d.y;
+            float h = (float) vec3d.z;
+            BackgroundRenderer.setFogBlack();
+            RenderSystem.depthMask(false);
+            RenderSystem.setShaderColor(f, g, h, 1.0F);
+            ShaderProgram shaderProgram = RenderSystem.getShader();
+            worldRendererAccess.getLightSkyBuffer().bind();
+            worldRendererAccess.getLightSkyBuffer().draw(matrices.peek().getPositionMatrix(), projectionMatrix, shaderProgram);
+            VertexBuffer.unbind();
+            RenderSystem.enableBlend();
+            float[] fs = world.getDimensionEffects().getFogColorOverride(world.getSkyAngle(tickDelta), tickDelta);
+            if (fs != null) {
+                RenderSystem.setShader(GameRenderer::getPositionColorProgram);
+                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+                matrices.push();
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
+                float i = MathHelper.sin(world.getSkyAngleRadians(tickDelta)) < 0.0F ? 180.0F : 0.0F;
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
+                float j = fs[0];
+                float k = fs[1];
+                float l = fs[2];
+                Matrix4f matrix4f = matrices.peek().getPositionMatrix();
+                bufferBuilder.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
+                bufferBuilder.vertex(matrix4f, 0.0F, 100.0F, 0.0F).color(j, k, l, fs[3]).next();
+
+                for (int n = 0; n <= 16; ++n) {
+                    float o = (float) n * (float) (Math.PI * 2) / 16.0F;
+                    float p = MathHelper.sin(o);
+                    float q = MathHelper.cos(o);
+                    bufferBuilder.vertex(matrix4f, p * 120.0F, q * 120.0F, -q * 40.0F * fs[3]).color(fs[0], fs[1], fs[2], 0.0F).next();
+                }
+
+                BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+                matrices.pop();
+            }
+            RenderSystem.depthMask(true);
+            RenderSystem.disableBlend();
         }
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
@@ -1,20 +1,11 @@
 package io.github.amerebagatelle.fabricskyboxes.mixin.skybox;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
-import io.github.amerebagatelle.fabricskyboxes.util.Constants;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.ShaderProgram;
-import net.minecraft.client.gl.VertexBuffer;
-import net.minecraft.client.render.*;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
-import net.minecraft.util.math.Vec3d;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -30,108 +21,8 @@ public abstract class SkyboxRenderMixin {
         SkyboxManager skyboxManager = SkyboxManager.getInstance();
         if (skyboxManager.isEnabled() && !skyboxManager.getActiveSkyboxes().isEmpty()) {
             runnable.run();
-            this.renderSky((WorldRendererAccess) this, matrices, matrix4f, tickDelta);
             skyboxManager.renderSkyboxes((WorldRendererAccess) this, matrices, matrix4f, tickDelta, camera, bl);
             ci.cancel();
-        }
-    }
-
-    // Vanilla copy of renderSky and renderEndSky with decorations stripped
-    @Unique
-    private void renderSky(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta) {
-        MinecraftClient client = MinecraftClient.getInstance();
-        ClientWorld world = client.world;
-        assert client.world != null;
-
-        BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
-
-        if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.END) {
-            RenderSystem.enableBlend();
-            RenderSystem.depthMask(false);
-            RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-            RenderSystem.setShaderTexture(0, WorldRendererAccess.getEndSky());
-            Tessellator tessellator = Tessellator.getInstance();
-
-            for (int i = 0; i < 6; ++i) {
-                matrices.push();
-                if (i == 1) {
-                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
-                }
-
-                if (i == 2) {
-                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90.0F));
-                }
-
-                if (i == 3) {
-                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
-                }
-
-                if (i == 4) {
-                    matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
-                }
-
-                if (i == 5) {
-                    matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
-                }
-
-                Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-                bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-                bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(0.0F, 0.0F).color(40, 40, 40, 255).next();
-                bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(0.0F, 16.0F).color(40, 40, 40, 255).next();
-                bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(16.0F, 16.0F).color(40, 40, 40, 255).next();
-                bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(16.0F, 0.0F).color(40, 40, 40, 255).next();
-                tessellator.draw();
-                matrices.pop();
-            }
-
-            RenderSystem.depthMask(true);
-            RenderSystem.disableBlend();
-        } else if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.NORMAL) {
-            Vec3d vec3d = world.getSkyColor(client.gameRenderer.getCamera().getPos(), tickDelta);
-            float f = (float) vec3d.x;
-            float g = (float) vec3d.y;
-            float h = (float) vec3d.z;
-            BackgroundRenderer.setFogBlack();
-            RenderSystem.depthMask(false);
-            RenderSystem.setShaderColor(f, g, h, 1.0F);
-            ShaderProgram shaderProgram = RenderSystem.getShader();
-            worldRendererAccess.getLightSkyBuffer().bind();
-            worldRendererAccess.getLightSkyBuffer().draw(matrices.peek().getPositionMatrix(), projectionMatrix, shaderProgram);
-            VertexBuffer.unbind();
-            RenderSystem.enableBlend();
-            //float skyAngle = world.getSkyAngle(tickDelta);
-            //float skyAngleRadian = world.getSkyAngleRadians(tickDelta);
-            float skyAngle = MathHelper.floorMod(world.getTimeOfDay() / 24000F + 0.75F, 1);
-            float skyAngleRadian = skyAngle * (float) (Math.PI * 2);
-
-            float[] fs = world.getDimensionEffects().getFogColorOverride(skyAngle, tickDelta);
-            if (fs != null) {
-                RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-                matrices.push();
-                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
-                float i = MathHelper.sin(skyAngleRadian) < 0.0F ? 180.0F : 0.0F;
-                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
-                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
-                float j = fs[0];
-                float k = fs[1];
-                float l = fs[2];
-                Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-                bufferBuilder.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
-                bufferBuilder.vertex(matrix4f, 0.0F, 100.0F, 0.0F).color(j, k, l, fs[3]).next();
-
-                for (int n = 0; n <= 16; ++n) {
-                    float o = (float) n * (float) (Math.PI * 2) / 16.0F;
-                    float p = MathHelper.sin(o);
-                    float q = MathHelper.cos(o);
-                    bufferBuilder.vertex(matrix4f, p * 120.0F, q * 120.0F, -q * 40.0F * fs[3]).color(fs[0], fs[1], fs[2], 0.0F).next();
-                }
-
-                BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-                matrices.pop();
-            }
-            RenderSystem.depthMask(true);
-            RenderSystem.disableBlend();
         }
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/SkyboxRenderMixin.java
@@ -99,13 +99,18 @@ public abstract class SkyboxRenderMixin {
             worldRendererAccess.getLightSkyBuffer().draw(matrices.peek().getPositionMatrix(), projectionMatrix, shaderProgram);
             VertexBuffer.unbind();
             RenderSystem.enableBlend();
-            float[] fs = world.getDimensionEffects().getFogColorOverride(world.getSkyAngle(tickDelta), tickDelta);
+            //float skyAngle = world.getSkyAngle(tickDelta);
+            //float skyAngleRadian = world.getSkyAngleRadians(tickDelta);
+            float skyAngle = MathHelper.floorMod(world.getTimeOfDay() / 24000F + 0.75F, 1);
+            float skyAngleRadian = skyAngle * (float) (Math.PI * 2);
+
+            float[] fs = world.getDimensionEffects().getFogColorOverride(skyAngle, tickDelta);
             if (fs != null) {
                 RenderSystem.setShader(GameRenderer::getPositionColorProgram);
                 RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
                 matrices.push();
                 matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
-                float i = MathHelper.sin(world.getSkyAngleRadians(tickDelta)) < 0.0F ? 180.0F : 0.0F;
+                float i = MathHelper.sin(skyAngleRadian) < 0.0F ? 180.0F : 0.0F;
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
                 matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
                 float j = fs[0];

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/WorldRendererAccess.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/mixin/skybox/WorldRendererAccess.java
@@ -20,6 +20,12 @@ public interface WorldRendererAccess {
         throw new AssertionError();
     }
 
+    @Deprecated
+    @Accessor("END_SKY")
+    static Identifier getEndSky() {
+        throw new AssertionError();
+    }
+
     @Accessor
     VertexBuffer getLightSkyBuffer();
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/resource/SkyboxResourceListener.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/resource/SkyboxResourceListener.java
@@ -11,8 +11,6 @@ import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 
 import java.io.InputStreamReader;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 public class SkyboxResourceListener implements SimpleSynchronousResourceReloadListener {
@@ -37,11 +35,6 @@ public class SkyboxResourceListener implements SimpleSynchronousResourceReloadLi
                 e.printStackTrace();
             }
         });
-    }
-
-    @Override
-    public Collection<Identifier> getFabricDependencies() {
-        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -260,10 +260,9 @@ public abstract class AbstractSkybox implements FSBSkybox {
 
         // Vanilla rotation
         //matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
-        //matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * this.decorations.getRotation().getRotationSpeed()));
-
         // Iris Compat
-        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(IrisCompat.getSunPathRotation()));
+        //matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(IrisCompat.getSunPathRotation()));
+        //matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * this.decorations.getRotation().getRotationSpeed()));
 
         float timeRotation = this.decorations.getRotation().getRotationSpeed() != 0F ? 360F * MathHelper.floorMod(world.getTimeOfDay() / (24000 / this.decorations.getRotation().getRotationSpeed()), 1) : 0;
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -1,7 +1,6 @@
 package io.github.amerebagatelle.fabricskyboxes.skyboxes;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import io.github.amerebagatelle.fabricskyboxes.IrisCompat;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.FSBSkybox;
 import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
 import io.github.amerebagatelle.fabricskyboxes.util.Constants;
@@ -264,9 +263,9 @@ public abstract class AbstractSkybox implements FSBSkybox {
         //matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(IrisCompat.getSunPathRotation()));
         //matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * this.decorations.getRotation().getRotationSpeed()));
 
-        float timeRotation = this.decorations.getRotation().getRotationSpeed() != 0F ? 360F * MathHelper.floorMod(world.getTimeOfDay() / (24000 / this.decorations.getRotation().getRotationSpeed()), 1) : 0;
+        double timeRotation = this.decorations.getRotation().getRotationSpeed() != 0F ? 360D * MathHelper.floorMod(world.getTimeOfDay() / (24000.0D / this.decorations.getRotation().getRotationSpeed()), 1) : 0D;
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
-        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(timeRotation));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees((float) timeRotation));
 
         // fixme: add rotationSpeed but for decorations?
         /* matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeed()));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -240,8 +240,12 @@ public abstract class AbstractSkybox implements FSBSkybox {
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationAxis.z()));
 
         // Vanilla rotation
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * this.decorations.getRotation().getRotationSpeed()));
+        //matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
+        //matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * this.decorations.getRotation().getRotationSpeed()));
+
+        float timeRotation = this.decorations.getRotation().getRotationSpeed() != 0F ? 360F * MathHelper.floorMod(world.getTimeOfDay() / (24000 / this.decorations.getRotation().getRotationSpeed()), 1) : 0;
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(timeRotation));
 
         // fixme: add rotationSpeed but for decorations?
         /* matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeed()));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -265,9 +265,6 @@ public abstract class AbstractSkybox implements FSBSkybox {
                 tessellator.draw();
                 matrices.pop();
             }
-
-            RenderSystem.depthMask(true);
-            RenderSystem.disableBlend();
         } else if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.NORMAL) {
             Vec3d vec3d = client.world.getSkyColor(client.gameRenderer.getCamera().getPos(), tickDelta);
             float f = (float) vec3d.x;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -221,75 +221,85 @@ public abstract class AbstractSkybox implements FSBSkybox {
     public abstract SkyboxType<? extends AbstractSkybox> getType();
 
     public void renderDecorations(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, BufferBuilder bufferBuilder, float alpha) {
-        if (!SkyboxManager.getInstance().hasRenderedDecorations()) {
-            Vector3f rotationStatic = decorations.getRotation().getStatic();
-            Vector3f rotationAxis = decorations.getRotation().getAxis();
+        Vector3f rotationStatic = decorations.getRotation().getStatic();
+        Vector3f rotationAxis = decorations.getRotation().getAxis();
+        ClientWorld world = MinecraftClient.getInstance().world;
+        assert world != null;
 
-            matrices.push();
-            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationStatic.x()));
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationStatic.y()));
-            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationStatic.z()));
-            ClientWorld world = MinecraftClient.getInstance().world;
-            assert world != null;
-            RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
-            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationAxis.x()));
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationAxis.y()));
-            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationAxis.z()));
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
-            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeed()));
-            matrices.multiply(RotationAxis.NEGATIVE_Z.rotationDegrees(rotationAxis.z()));
-            matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(rotationAxis.y()));
-            matrices.multiply(RotationAxis.NEGATIVE_X.rotationDegrees(rotationAxis.x()));
-            // sun
-            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
-            Matrix4f matrix4f2 = matrices.peek().getPositionMatrix();
-            float s = 30.0F;
-            RenderSystem.setShader(GameRenderer::getPositionTexProgram);
-            if (decorations.isSunEnabled()) {
-                RenderSystem.setShaderTexture(0, this.decorations.getSunTexture());
-                bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
-                bufferBuilder.vertex(matrix4f2, -s, 100.0F, -s).texture(0.0F, 0.0F).next();
-                bufferBuilder.vertex(matrix4f2, s, 100.0F, -s).texture(1.0F, 0.0F).next();
-                bufferBuilder.vertex(matrix4f2, s, 100.0F, s).texture(1.0F, 1.0F).next();
-                bufferBuilder.vertex(matrix4f2, -s, 100.0F, s).texture(0.0F, 1.0F).next();
-                BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-            }
-            // moon
-            s = 20.0F;
-            if (decorations.isMoonEnabled()) {
-                RenderSystem.setShaderTexture(0, this.decorations.getMoonTexture());
-                int u = world.getMoonPhase();
-                int v = u % 4;
-                int w = u / 4 % 2;
-                float x = v / 4.0F;
-                float p = w / 2.0F;
-                float q = (v + 1) / 4.0F;
-                float r = (w + 1) / 2.0F;
-                bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
-                bufferBuilder.vertex(matrix4f2, -s, -100.0F, s).texture(q, r).next();
-                bufferBuilder.vertex(matrix4f2, s, -100.0F, s).texture(x, r).next();
-                bufferBuilder.vertex(matrix4f2, s, -100.0F, -s).texture(x, p).next();
-                bufferBuilder.vertex(matrix4f2, -s, -100.0F, -s).texture(q, p).next();
-                BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-            }
-            // stars
-            if (decorations.isStarsEnabled()) {
-                float ab = world.method_23787(tickDelta) * s;
-                if (ab > 0.0F) {
-                    RenderSystem.setShaderColor(ab, ab, ab, ab);
-                    BackgroundRenderer.clearFog();
-                    worldRendererAccess.getStarsBuffer().bind();
-                    worldRendererAccess.getStarsBuffer().draw(matrices.peek().getPositionMatrix(), matrix4f, GameRenderer.getPositionProgram());
-                    VertexBuffer.unbind();
-                }
-            }
-            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationStatic.z()));
-            matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationStatic.y()));
-            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationStatic.x()));
-            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-            RenderSystem.disableBlend();
-            matrices.pop();
+        RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
+        matrices.push();
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
+        // static rotation
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationStatic.x()));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationStatic.y()));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationStatic.z()));
+
+        // axis rotation
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationAxis.x()));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationAxis.y()));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationAxis.z()));
+
+        // Vanilla rotation
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F));
+
+        // fixme: add rotationSpeed but for decorations?
+        /* matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeed()));
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeedX()));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeedY()));
+        matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeedZ()));*/
+
+        // axis rotation
+        matrices.multiply(RotationAxis.NEGATIVE_Z.rotationDegrees(rotationAxis.z()));
+        matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(rotationAxis.y()));
+        matrices.multiply(RotationAxis.NEGATIVE_X.rotationDegrees(rotationAxis.x()));
+
+
+        Matrix4f matrix4f2 = matrices.peek().getPositionMatrix();
+        RenderSystem.setShader(GameRenderer::getPositionTexProgram);
+        // Sun
+        if (this.decorations.isSunEnabled() && !SkyboxManager.getInstance().hasRenderedSun()) {
+            RenderSystem.setShaderTexture(0, this.decorations.getSunTexture());
+            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
+            bufferBuilder.vertex(matrix4f2, -30.0F, 100.0F, -30.0F).texture(0.0F, 0.0F).next();
+            bufferBuilder.vertex(matrix4f2, 30.0F, 100.0F, -30.0F).texture(1.0F, 0.0F).next();
+            bufferBuilder.vertex(matrix4f2, 30.0F, 100.0F, 30.0F).texture(1.0F, 1.0F).next();
+            bufferBuilder.vertex(matrix4f2, -30.0F, 100.0F, 30.0F).texture(0.0F, 1.0F).next();
+            BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
         }
+        // Moon
+        if (this.decorations.isMoonEnabled() && !SkyboxManager.getInstance().hasRenderedMoon()) {
+            RenderSystem.setShaderTexture(0, this.decorations.getMoonTexture());
+            int moonPhase = world.getMoonPhase();
+            int xCoord = moonPhase % 4;
+            int yCoord = moonPhase / 4 % 2;
+            float startX = xCoord / 4.0F;
+            float startY = yCoord / 2.0F;
+            float endX = (xCoord + 1) / 4.0F;
+            float endY = (yCoord + 1) / 2.0F;
+            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
+            bufferBuilder.vertex(matrix4f2, -20.0F, -100.0F, 20.0F).texture(endX, endY).next();
+            bufferBuilder.vertex(matrix4f2, 20.0F, -100.0F, 20.0F).texture(startX, endY).next();
+            bufferBuilder.vertex(matrix4f2, 20.0F, -100.0F, -20.0F).texture(startX, startY).next();
+            bufferBuilder.vertex(matrix4f2, -20.0F, -100.0F, -20.0F).texture(endX, startY).next();
+            BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+        }
+        // Stars
+        if (this.decorations.isStarsEnabled() && !SkyboxManager.getInstance().hasRenderedStars()) {
+            float i = 1.0F - world.getRainGradient(tickDelta);
+            float brightness = world.method_23787(tickDelta) * i;
+            if (brightness > 0.0F) {
+                RenderSystem.setShaderColor(brightness, brightness, brightness, brightness);
+                BackgroundRenderer.clearFog();
+                worldRendererAccess.getStarsBuffer().bind();
+                worldRendererAccess.getStarsBuffer().draw(matrices.peek().getPositionMatrix(), matrix4f, GameRenderer.getPositionProgram());
+                VertexBuffer.unbind();
+            }
+        }
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.disableBlend();
+        RenderSystem.defaultBlendFunc();
+        matrices.pop();
     }
 
     @Override

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -241,7 +241,7 @@ public abstract class AbstractSkybox implements FSBSkybox {
 
         // Vanilla rotation
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
-        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F));
+        matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * this.decorations.getRotation().getRotationSpeed()));
 
         // fixme: add rotationSpeed but for decorations?
         /* matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeed()));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -8,7 +8,6 @@ import io.github.amerebagatelle.fabricskyboxes.util.Constants;
 import io.github.amerebagatelle.fabricskyboxes.util.Utils;
 import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gl.ShaderProgram;
 import net.minecraft.client.gl.VertexBuffer;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.*;
@@ -19,7 +18,6 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RotationAxis;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.biome.Biome;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
@@ -220,98 +218,8 @@ public abstract class AbstractSkybox implements FSBSkybox {
 
     public abstract SkyboxType<? extends AbstractSkybox> getType();
 
-    public void renderVanillaSkyBox(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta) {
-        if (!this.decorations.isVanillaSkyEnabled())
-            return;
-
-        MinecraftClient client = MinecraftClient.getInstance();
-        Objects.requireNonNull(client.world);
-        if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.END) {
-            RenderSystem.enableBlend();
-            RenderSystem.depthMask(false);
-            RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-            RenderSystem.setShaderTexture(0, WorldRendererAccess.getEndSky());
-            Tessellator tessellator = Tessellator.getInstance();
-            BufferBuilder bufferBuilder = tessellator.getBuffer();
-
-            for (int i = 0; i < 6; ++i) {
-                matrices.push();
-                if (i == 1) {
-                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
-                }
-
-                if (i == 2) {
-                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90.0F));
-                }
-
-                if (i == 3) {
-                    matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
-                }
-
-                if (i == 4) {
-                    matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
-                }
-
-                if (i == 5) {
-                    matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
-                }
-
-                Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-                bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-                bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(0.0F, 0.0F).color(40, 40, 40, 255).next();
-                bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(0.0F, 16.0F).color(40, 40, 40, 255).next();
-                bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(16.0F, 16.0F).color(40, 40, 40, 255).next();
-                bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(16.0F, 0.0F).color(40, 40, 40, 255).next();
-                tessellator.draw();
-                matrices.pop();
-            }
-        } else if (client.world.getDimensionEffects().getSkyType() == DimensionEffects.SkyType.NORMAL) {
-            Vec3d vec3d = client.world.getSkyColor(client.gameRenderer.getCamera().getPos(), tickDelta);
-            float f = (float) vec3d.x;
-            float g = (float) vec3d.y;
-            float h = (float) vec3d.z;
-            BackgroundRenderer.setFogBlack();
-            BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
-            RenderSystem.depthMask(false);
-            RenderSystem.setShaderColor(f, g, h, 1.0F);
-            ShaderProgram shaderProgram = RenderSystem.getShader();
-            worldRendererAccess.getLightSkyBuffer().bind();
-            worldRendererAccess.getLightSkyBuffer().draw(matrices.peek().getPositionMatrix(), projectionMatrix, shaderProgram);
-            VertexBuffer.unbind();
-            RenderSystem.enableBlend();
-            //float skyAngle = 360F * MathHelper.floorMod(client.world.getTimeOfDay() / 24000F + 0.75F, 1);
-            //float skyAngleRadian = (float) (skyAngle * Math.PI / 180F);
-            //float[] fs = client.world.getDimensionEffects().getFogColorOverride(skyAngle, tickDelta);
-            float[] fs = client.world.getDimensionEffects().getFogColorOverride(client.world.getSkyAngle(tickDelta), tickDelta);
-            if (fs != null) {
-                RenderSystem.setShader(GameRenderer::getPositionColorProgram);
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-                matrices.push();
-                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
-                float i = MathHelper.sin(client.world.getSkyAngleRadians(tickDelta)) < 0.0F ? 180.0F : 0.0F;
-                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
-                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
-                float j = fs[0];
-                float k = fs[1];
-                float l = fs[2];
-                Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-                bufferBuilder.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
-                bufferBuilder.vertex(matrix4f, 0.0F, 100.0F, 0.0F).color(j, k, l, fs[3]).next();
-
-                for (int n = 0; n <= 16; ++n) {
-                    float o = (float) n * (float) (Math.PI * 2) / 16.0F;
-                    float p = MathHelper.sin(o);
-                    float q = MathHelper.cos(o);
-                    bufferBuilder.vertex(matrix4f, p * 120.0F, q * 120.0F, -q * 40.0F * fs[3]).color(fs[0], fs[1], fs[2], 0.0F).next();
-                }
-
-                BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-                matrices.pop();
-            }
-        }
-    }
-
     public void renderDecorations(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, BufferBuilder bufferBuilder, float alpha) {
+        RenderSystem.enableBlend();
         Vector3f rotationStatic = decorations.getRotation().getStatic();
         Vector3f rotationAxis = decorations.getRotation().getAxis();
         ClientWorld world = MinecraftClient.getInstance().world;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -1,7 +1,6 @@
 package io.github.amerebagatelle.fabricskyboxes.skyboxes;
 
 import com.google.common.collect.Range;
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.FSBSkybox;
@@ -226,9 +225,9 @@ public abstract class AbstractSkybox implements FSBSkybox {
         ClientWorld world = MinecraftClient.getInstance().world;
         assert world != null;
 
-        RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
+        // Custom Blender
+        this.decorations.getBlend().applyBlendFunc(alpha);
         matrices.push();
-        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
         // static rotation
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationStatic.x()));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationStatic.y()));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/EndSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/EndSkybox.java
@@ -1,0 +1,82 @@
+package io.github.amerebagatelle.fabricskyboxes.skyboxes;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
+import io.github.amerebagatelle.fabricskyboxes.util.object.Conditions;
+import io.github.amerebagatelle.fabricskyboxes.util.object.Decorations;
+import io.github.amerebagatelle.fabricskyboxes.util.object.Properties;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.*;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.RotationAxis;
+import org.joml.Matrix4f;
+
+public class EndSkybox extends AbstractSkybox {
+    public static Codec<EndSkybox> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Properties.CODEC.fieldOf("properties").forGetter(AbstractSkybox::getProperties),
+            Conditions.CODEC.optionalFieldOf("conditions", Conditions.DEFAULT).forGetter(AbstractSkybox::getConditions),
+            Decorations.CODEC.optionalFieldOf("decorations", Decorations.DEFAULT).forGetter(AbstractSkybox::getDecorations)
+    ).apply(instance, EndSkybox::new));
+
+    public EndSkybox(Properties properties, Conditions conditions, Decorations decorations) {
+        super(properties, conditions, decorations);
+    }
+
+    @Override
+    public SkyboxType<? extends AbstractSkybox> getType() {
+        return SkyboxType.MONO_COLOR_SKYBOX;
+    }
+
+    @Override
+    public void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta, Camera camera, boolean thickFog) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        assert client.world != null;
+
+        BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
+
+        RenderSystem.enableBlend();
+        RenderSystem.depthMask(false);
+        RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
+        RenderSystem.setShaderTexture(0, WorldRendererAccess.getEndSky());
+        Tessellator tessellator = Tessellator.getInstance();
+
+        for (int i = 0; i < 6; ++i) {
+            matrices.push();
+            if (i == 1) {
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
+            }
+
+            if (i == 2) {
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90.0F));
+            }
+
+            if (i == 3) {
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
+            }
+
+            if (i == 4) {
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
+            }
+
+            if (i == 5) {
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
+            }
+
+            Matrix4f matrix4f = matrices.peek().getPositionMatrix();
+            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(0.0F, 0.0F).color(40 / 255F, 40 / 255F, 40 / 255F, 255 * this.alpha).next();
+            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(0.0F, 16.0F).color(40 / 255F, 40 / 255F, 40 / 255F, 255 * this.alpha).next();
+            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(16.0F, 16.0F).color(40 / 255F, 40 / 255F, 40 / 255F, 255 * this.alpha).next();
+            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(16.0F, 0.0F).color(40 / 255F, 40 / 255F, 40 / 255F, 255 * this.alpha).next();
+            tessellator.draw();
+            matrices.pop();
+        }
+
+        this.renderDecorations(worldRendererAccess, matrices, projectionMatrix, tickDelta, bufferBuilder, this.alpha);
+
+        RenderSystem.depthMask(true);
+        RenderSystem.disableBlend();
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/LegacyDeserializer.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/LegacyDeserializer.java
@@ -31,7 +31,7 @@ public class LegacyDeserializer<T extends AbstractSkybox> {
     private static void decodeSquareTextured(JsonObjectWrapper wrapper, AbstractSkybox skybox) {
         decodeSharedData(wrapper, skybox);
         ((SquareTexturedSkybox) skybox).rotation = new Rotation(new Vector3f(0f, 0f, 0f), new Vector3f(wrapper.getOptionalArrayFloat("axis", 0, 0), wrapper.getOptionalArrayFloat("axis", 1, 0), wrapper.getOptionalArrayFloat("axis", 2, 0)), 1);
-        ((SquareTexturedSkybox) skybox).blend = new Blend(wrapper.getOptionalBoolean("shouldBlend", false) ? "add" : "", 0, 0, 0, false, false, false, true);
+        ((SquareTexturedSkybox) skybox).blend = new Blend(wrapper.getOptionalBoolean("shouldBlend", false) ? "add" : "", Blender.DEFAULT);
         ((SquareTexturedSkybox) skybox).textures = new Textures(
                 new Texture(wrapper.getJsonStringAsId("texture_north")),
                 new Texture(wrapper.getJsonStringAsId("texture_south")),

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/OverworldSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/OverworldSkybox.java
@@ -1,0 +1,92 @@
+package io.github.amerebagatelle.fabricskyboxes.skyboxes;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
+import io.github.amerebagatelle.fabricskyboxes.util.object.Conditions;
+import io.github.amerebagatelle.fabricskyboxes.util.object.Decorations;
+import io.github.amerebagatelle.fabricskyboxes.util.object.Properties;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.ShaderProgram;
+import net.minecraft.client.gl.VertexBuffer;
+import net.minecraft.client.render.*;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.RotationAxis;
+import net.minecraft.util.math.Vec3d;
+import org.joml.Matrix4f;
+
+public class OverworldSkybox extends AbstractSkybox {
+    public static Codec<OverworldSkybox> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Properties.CODEC.fieldOf("properties").forGetter(AbstractSkybox::getProperties),
+            Conditions.CODEC.optionalFieldOf("conditions", Conditions.DEFAULT).forGetter(AbstractSkybox::getConditions),
+            Decorations.CODEC.optionalFieldOf("decorations", Decorations.DEFAULT).forGetter(AbstractSkybox::getDecorations)
+    ).apply(instance, OverworldSkybox::new));
+
+    public OverworldSkybox(Properties properties, Conditions conditions, Decorations decorations) {
+        super(properties, conditions, decorations);
+    }
+
+    @Override
+    public SkyboxType<? extends AbstractSkybox> getType() {
+        return SkyboxType.MONO_COLOR_SKYBOX;
+    }
+
+    @Override
+    public void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f projectionMatrix, float tickDelta, Camera camera, boolean thickFog) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        ClientWorld world = client.world;
+        assert client.world != null;
+
+        BufferBuilder bufferBuilder = Tessellator.getInstance().getBuffer();
+
+        Vec3d vec3d = world.getSkyColor(client.gameRenderer.getCamera().getPos(), tickDelta);
+        float f = (float) vec3d.x;
+        float g = (float) vec3d.y;
+        float h = (float) vec3d.z;
+        BackgroundRenderer.setFogBlack();
+        RenderSystem.depthMask(false);
+        RenderSystem.setShaderColor(f, g, h, this.alpha);
+        ShaderProgram shaderProgram = RenderSystem.getShader();
+        worldRendererAccess.getLightSkyBuffer().bind();
+        worldRendererAccess.getLightSkyBuffer().draw(matrices.peek().getPositionMatrix(), projectionMatrix, shaderProgram);
+        VertexBuffer.unbind();
+        RenderSystem.enableBlend();
+        float skyAngle = MathHelper.floorMod(world.getTimeOfDay() / 24000F + 0.75F, 1);
+        float skyAngleRadian = skyAngle * (float) (Math.PI * 2);
+
+        float[] fs = world.getDimensionEffects().getFogColorOverride(skyAngle, tickDelta);
+        if (fs != null) {
+            RenderSystem.setShader(GameRenderer::getPositionColorProgram);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            matrices.push();
+            matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
+            float i = MathHelper.sin(skyAngleRadian) < 0.0F ? 180.0F : 0.0F;
+            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(i));
+            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
+            float j = fs[0];
+            float k = fs[1];
+            float l = fs[2];
+            Matrix4f matrix4f = matrices.peek().getPositionMatrix();
+            bufferBuilder.begin(VertexFormat.DrawMode.TRIANGLE_FAN, VertexFormats.POSITION_COLOR);
+            bufferBuilder.vertex(matrix4f, 0.0F, 100.0F, 0.0F).color(j, k, l, fs[3] * this.alpha).next();
+
+            for (int n = 0; n <= 16; ++n) {
+                float o = (float) n * (float) (Math.PI * 2) / 16.0F;
+                float p = MathHelper.sin(o);
+                float q = MathHelper.cos(o);
+                bufferBuilder.vertex(matrix4f, p * 120.0F, q * 120.0F, -q * 40.0F * fs[3]).color(fs[0], fs[1], fs[2], 0.0F).next();
+            }
+
+            BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
+            matrices.pop();
+        }
+
+        this.renderDecorations(worldRendererAccess, matrices, projectionMatrix, tickDelta, bufferBuilder, this.alpha);
+
+        RenderSystem.depthMask(true);
+        RenderSystem.disableBlend();
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
@@ -55,12 +55,6 @@ public class SkyboxType<T extends AbstractSkybox> {
         });
     }
 
-    public static void initRegistry() {
-        if (REGISTRY == null) {
-            System.err.println("[FabricSkyboxes] Registry not loaded?");
-        }
-    }
-
     private final BiMap<Integer, Codec<T>> codecBiMap;
     private final boolean legacySupported;
     private final String name;
@@ -68,13 +62,18 @@ public class SkyboxType<T extends AbstractSkybox> {
     private final Supplier<T> factory;
     @Nullable
     private final LegacyDeserializer<T> deserializer;
-
     private SkyboxType(BiMap<Integer, Codec<T>> codecBiMap, boolean legacySupported, String name, @Nullable Supplier<T> factory, @Nullable LegacyDeserializer<T> deserializer) {
         this.codecBiMap = codecBiMap;
         this.legacySupported = legacySupported;
         this.name = name;
         this.factory = factory;
         this.deserializer = deserializer;
+    }
+
+    public static void initRegistry() {
+        if (REGISTRY == null) {
+            System.err.println("[FabricSkyboxes] Registry not loaded?");
+        }
     }
 
     private static <T extends AbstractSkybox> SkyboxType<T> register(SkyboxType<T> type) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
@@ -25,6 +25,8 @@ import java.util.function.Supplier;
 public class SkyboxType<T extends AbstractSkybox> {
     public static final Registry<SkyboxType<? extends AbstractSkybox>> REGISTRY;
     public static final SkyboxType<MonoColorSkybox> MONO_COLOR_SKYBOX;
+    public static final SkyboxType<OverworldSkybox> OVERWORLD_SKYBOX;
+    public static final SkyboxType<EndSkybox> END_SKYBOX;
     public static final SkyboxType<SquareTexturedSkybox> SQUARE_TEXTURED_SKYBOX;
     public static final SkyboxType<SingleSpriteSquareTexturedSkybox> SINGLE_SPRITE_SQUARE_TEXTURED_SKYBOX;
     public static final SkyboxType<AnimatedSquareTexturedSkybox> ANIMATED_SQUARE_TEXTURED_SKYBOX;
@@ -34,6 +36,8 @@ public class SkyboxType<T extends AbstractSkybox> {
     static {
         REGISTRY = FabricRegistryBuilder.<SkyboxType<? extends AbstractSkybox>, SimpleRegistry<SkyboxType<? extends AbstractSkybox>>>from(new SimpleRegistry<>(RegistryKey.ofRegistry(new Identifier(FabricSkyBoxesClient.MODID, "skybox_type")), Lifecycle.stable())).buildAndRegister();
         MONO_COLOR_SKYBOX = register(SkyboxType.Builder.create(MonoColorSkybox.class, "monocolor").legacySupported().deserializer(LegacyDeserializer.MONO_COLOR_SKYBOX_DESERIALIZER).factory(MonoColorSkybox::new).add(2, MonoColorSkybox.CODEC).build());
+        OVERWORLD_SKYBOX = register(SkyboxType.Builder.create(OverworldSkybox.class, "overworld").add(2, OverworldSkybox.CODEC).build());
+        END_SKYBOX = register(SkyboxType.Builder.create(EndSkybox.class, "end").add(2, EndSkybox.CODEC).build());
         SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(SquareTexturedSkybox.class, "square-textured").deserializer(LegacyDeserializer.SQUARE_TEXTURED_SKYBOX_DESERIALIZER).legacySupported().factory(SquareTexturedSkybox::new).add(2, SquareTexturedSkybox.CODEC).build());
         SINGLE_SPRITE_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(SingleSpriteSquareTexturedSkybox.class, "single-sprite-square-textured").add(2, SingleSpriteSquareTexturedSkybox.CODEC).build());
         ANIMATED_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(AnimatedSquareTexturedSkybox.class, "animated-square-textured").add(2, AnimatedSquareTexturedSkybox.CODEC).build());

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
@@ -41,6 +41,7 @@ public abstract class TexturedSkybox extends AbstractSkybox implements Rotatable
      */
     @Override
     public final void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
+        this.renderVanillaSkyBox(worldRendererAccess, matrices, matrix4f, tickDelta);
         RenderSystem.depthMask(false);
         RenderSystem.enableBlend();
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
@@ -52,8 +52,8 @@ public abstract class TexturedSkybox extends AbstractSkybox implements Rotatable
         Vector3f rotationStatic = this.rotation.getStatic();
 
         matrices.push();
-        float timeRotation = this.getProperties().isShouldRotate() && this.rotation.getRotationSpeed() != 0F ? 360F * MathHelper.floorMod(world.getTimeOfDay() / (24000 / this.rotation.getRotationSpeed()) + 0.75F, 1) : 0;
-        this.applyTimeRotation(matrices, timeRotation);
+        double timeRotation = this.getProperties().isShouldRotate() && this.rotation.getRotationSpeed() != 0F ? 360.0D * MathHelper.floorMod(world.getLunarTime() / (24000.D / this.rotation.getRotationSpeed()) + 0.75D, 1) : 0D;
+        this.applyTimeRotation(matrices, (float) timeRotation);
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rotationStatic.x()));
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationStatic.y()));
         matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationStatic.z()));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/TexturedSkybox.java
@@ -41,7 +41,6 @@ public abstract class TexturedSkybox extends AbstractSkybox implements Rotatable
      */
     @Override
     public final void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
-        this.renderVanillaSkyBox(worldRendererAccess, matrices, matrix4f, tickDelta);
         RenderSystem.depthMask(false);
         RenderSystem.enableBlend();
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -5,86 +5,73 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.amerebagatelle.fabricskyboxes.FabricSkyBoxesClient;
-import org.lwjgl.opengl.GL14;
 
-import java.util.Arrays;
 import java.util.function.Consumer;
 
 public class Blend {
-    public static final Blend DEFAULT = new Blend("", 0, 0, 0, false, false, false, true);
+    public static final Blend DEFAULT = new Blend("", Blender.DEFAULT);
+    public static final Blend DECORATIONS = new Blend("decorations", Blender.DECORATIONS);
     public static Codec<Blend> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.optionalFieldOf("type", "").forGetter(Blend::getType),
-            Codec.INT.optionalFieldOf("sFactor", -1).forGetter(Blend::getSFactor),
-            Codec.INT.optionalFieldOf("dFactor", -1).forGetter(Blend::getDFactor),
-            Codec.INT.optionalFieldOf("equation", -1).forGetter(Blend::getEquation),
-            Codec.BOOL.optionalFieldOf("redAlphaEnabled", false).forGetter(Blend::isRedAlphaEnabled),
-            Codec.BOOL.optionalFieldOf("greenAlphaEnabled", false).forGetter(Blend::isGreenAlphaEnabled),
-            Codec.BOOL.optionalFieldOf("blueAlphaEnabled", false).forGetter(Blend::isBlueAlphaEnabled),
-            Codec.BOOL.optionalFieldOf("alphaEnabled", true).forGetter(Blend::isAlphaEnabled)
+            Blender.CODEC.optionalFieldOf("blender", Blender.DEFAULT).forGetter(Blend::getBlender)
     ).apply(instance, Blend::new));
     private final String type;
-    private final int sFactor;
-    private final int dFactor;
-    private final int equation;
-    private final boolean redAlphaEnabled;
-    private final boolean greenAlphaEnabled;
-    private final boolean blueAlphaEnabled;
-    private final boolean alphaEnabled;
+    private final Blender blender;
 
     private final Consumer<Float> blendFunc;
 
-    public Blend(String type, int sFactor, int dFactor, int equation, boolean redAlphaEnabled, boolean greenAlphaEnabled, boolean blueAlphaEnabled, boolean alphaEnabled) {
+    public Blend(String type, Blender blender) {
         this.type = type;
-        this.sFactor = sFactor;
-        this.dFactor = dFactor;
-        this.equation = equation;
-        this.redAlphaEnabled = redAlphaEnabled;
-        this.greenAlphaEnabled = greenAlphaEnabled;
-        this.blueAlphaEnabled = blueAlphaEnabled;
-        this.alphaEnabled = alphaEnabled;
+        this.blender = blender;
 
         if (!type.isEmpty()) {
             switch (type) {
                 case "add" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
                 case "subtract" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE_MINUS_DST_COLOR, GlStateManager.DstFactor.ZERO);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "multiply" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, alpha);
                 };
                 case "screen" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "replace" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
                 case "alpha" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
                 };
                 case "burn" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "dodge" -> blendFunc = (alpha) -> {
                     RenderSystem.blendFunc(GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE);
-                    RenderSystem.blendEquation(Equation.ADD.value);
+                    RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
+                case "disable" -> blendFunc = (alpha) -> {
+                    RenderSystem.disableBlend();
+                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
+                };
+                case "decorations" -> blendFunc = Blender.DECORATIONS::applyBlendFunc;
+                case "custom" -> blendFunc = this.blender::applyBlendFunc;
                 default -> {
                     FabricSkyBoxesClient.getLogger().error("Blend mode is set to an invalid or unsupported value.");
                     blendFunc = (alpha) -> {
@@ -93,12 +80,6 @@ public class Blend {
                     };
                 }
             }
-        } else if (this.isValidFactor(sFactor) && this.isValidFactor(dFactor) && this.isValidEquation(equation)) {
-            blendFunc = (alpha) -> {
-                RenderSystem.blendFunc(sFactor, dFactor);
-                RenderSystem.blendEquation(equation);
-                RenderSystem.setShaderColor(redAlphaEnabled ? alpha : 1.0F, greenAlphaEnabled ? alpha : 1.0F, blueAlphaEnabled ? alpha : 1.0F, alphaEnabled ? alpha : 1.0F);
-            };
         } else {
             blendFunc = (alpha) -> {
                 RenderSystem.defaultBlendFunc();
@@ -115,53 +96,7 @@ public class Blend {
         return type;
     }
 
-    public int getSFactor() {
-        return sFactor;
-    }
-
-    public int getDFactor() {
-        return dFactor;
-    }
-
-    public int getEquation() {
-        return equation;
-    }
-
-    public boolean isRedAlphaEnabled() {
-        return redAlphaEnabled;
-    }
-
-    public boolean isGreenAlphaEnabled() {
-        return greenAlphaEnabled;
-    }
-
-    public boolean isBlueAlphaEnabled() {
-        return blueAlphaEnabled;
-    }
-
-    public boolean isAlphaEnabled() {
-        return alphaEnabled;
-    }
-
-    public boolean isValidFactor(int factor) {
-        return Arrays.stream(GlStateManager.SrcFactor.values()).filter(factor1 -> factor == factor1.value).count() == 1;
-    }
-
-    public boolean isValidEquation(int equation) {
-        return Arrays.stream(Equation.values()).filter(equation1 -> equation == equation1.value).count() == 1;
-    }
-
-    public enum Equation {
-        ADD(GL14.GL_FUNC_ADD),
-        SUBTRACT(GL14.GL_FUNC_SUBTRACT),
-        REVERSE_SUBTRACT(GL14.GL_FUNC_REVERSE_SUBTRACT),
-        MIN(GL14.GL_MIN),
-        MAX(GL14.GL_MAX);
-
-        public final int value;
-
-        Equation(int value) {
-            this.value = value;
-        }
+    public Blender getBlender() {
+        return blender;
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blend.java
@@ -37,7 +37,7 @@ public class Blend {
                     RenderSystem.setShaderColor(alpha, alpha, alpha, 1.0F);
                 };
                 case "multiply" -> blendFunc = (alpha) -> {
-                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ZERO);
+                    RenderSystem.blendFunc(GlStateManager.SrcFactor.DST_COLOR, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
                     RenderSystem.blendEquation(Blender.Equation.ADD.value);
                     RenderSystem.setShaderColor(alpha, alpha, alpha, alpha);
                 };

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blender.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blender.java
@@ -1,0 +1,142 @@
+package io.github.amerebagatelle.fabricskyboxes.util.object;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.amerebagatelle.fabricskyboxes.FabricSkyBoxesClient;
+import org.lwjgl.opengl.GL14;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class Blender {
+    public static final Blender DEFAULT = new Blender(false, -1, -1, -1, -1, -1, false, false, false, true);
+    public static final Blender DECORATIONS = new Blender(true, 770, 1, 32774, 1, 0, false, false, false, true);
+
+    public static Codec<Blender> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Codec.BOOL.optionalFieldOf("separateFunction", false).forGetter(Blender::isSeparateFunction),
+            Codec.INT.optionalFieldOf("sourceFactor", -1).forGetter(Blender::getsFactor),
+            Codec.INT.optionalFieldOf("destinationFactor", -1).forGetter(Blender::getdFactor),
+            Codec.INT.optionalFieldOf("equation", -1).forGetter(Blender::getEquation),
+            Codec.INT.optionalFieldOf("sourceFactorAlpha", -1).forGetter(Blender::getsFactor2),
+            Codec.INT.optionalFieldOf("destinationFactorAlpha", -1).forGetter(Blender::getDestinationFactorAlpha),
+            Codec.BOOL.optionalFieldOf("redAlphaEnabled", false).forGetter(Blender::isRedAlphaEnabled),
+            Codec.BOOL.optionalFieldOf("greenAlphaEnabled", false).forGetter(Blender::isGreenAlphaEnabled),
+            Codec.BOOL.optionalFieldOf("blueAlphaEnabled", false).forGetter(Blender::isBlueAlphaEnabled),
+            Codec.BOOL.optionalFieldOf("alphaEnabled", true).forGetter(Blender::isAlphaEnabled)
+    ).apply(instance, Blender::new));
+
+    private final boolean separateFunction;
+
+    private final int sFactor;
+    private final int dFactor;
+    private final int equation;
+
+    private final int sourceFactorAlpha;
+    private final int destinationFactorAlpha;
+
+    private final boolean redAlphaEnabled;
+    private final boolean greenAlphaEnabled;
+    private final boolean blueAlphaEnabled;
+    private final boolean alphaEnabled;
+
+    private final Consumer<Float> blendFunc;
+
+    public Blender(boolean separateFunction, int sFactor, int dFactor, int equation, int sourceFactorAlpha, int destinationFactorAlpha, boolean redAlphaEnabled, boolean greenAlphaEnabled, boolean blueAlphaEnabled, boolean alphaEnabled) {
+        this.separateFunction = separateFunction;
+        this.sFactor = sFactor;
+        this.dFactor = dFactor;
+        this.equation = equation;
+        this.sourceFactorAlpha = sourceFactorAlpha;
+        this.destinationFactorAlpha = destinationFactorAlpha;
+        this.redAlphaEnabled = redAlphaEnabled;
+        this.greenAlphaEnabled = greenAlphaEnabled;
+        this.blueAlphaEnabled = blueAlphaEnabled;
+        this.alphaEnabled = alphaEnabled;
+
+        if ((this.separateFunction && this.isValidFactor(sFactor) && this.isValidFactor(dFactor) && this.isValidFactor(sourceFactorAlpha) && this.isValidFactor(destinationFactorAlpha) && this.isValidEquation(equation)) || (this.isValidFactor(sFactor) && this.isValidFactor(dFactor) && this.isValidEquation(equation))) {
+            this.blendFunc = (alpha) -> {
+                if (this.separateFunction) {
+                    RenderSystem.blendFuncSeparate(this.sFactor, this.dFactor, this.sourceFactorAlpha, this.destinationFactorAlpha);
+                } else {
+                    RenderSystem.blendFunc(this.sFactor, this.dFactor);
+                }
+                RenderSystem.blendEquation(this.equation);
+                RenderSystem.setShaderColor(this.redAlphaEnabled ? alpha : 1.0F, this.greenAlphaEnabled ? alpha : 1.0F, this.blueAlphaEnabled ? alpha : 1.0F, this.alphaEnabled ? alpha : 1.0F);
+            };
+        } else {
+            FabricSkyBoxesClient.getLogger().error("Invalid blend factors/equations in custom blender!");
+            this.blendFunc = (alpha) -> {
+                RenderSystem.defaultBlendFunc();
+                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
+            };
+        }
+    }
+
+    public void applyBlendFunc(float alpha) {
+        this.blendFunc.accept(alpha);
+    }
+
+    public boolean isSeparateFunction() {
+        return separateFunction;
+    }
+
+    public int getsFactor() {
+        return sFactor;
+    }
+
+    public int getdFactor() {
+        return dFactor;
+    }
+
+    public int getEquation() {
+        return equation;
+    }
+
+    public int getsFactor2() {
+        return sourceFactorAlpha;
+    }
+
+    public int getDestinationFactorAlpha() {
+        return destinationFactorAlpha;
+    }
+
+    public boolean isRedAlphaEnabled() {
+        return redAlphaEnabled;
+    }
+
+    public boolean isGreenAlphaEnabled() {
+        return greenAlphaEnabled;
+    }
+
+    public boolean isBlueAlphaEnabled() {
+        return blueAlphaEnabled;
+    }
+
+    public boolean isAlphaEnabled() {
+        return alphaEnabled;
+    }
+
+    public boolean isValidFactor(int factor) {
+        return Arrays.stream(GlStateManager.SrcFactor.values()).filter(factor1 -> factor == factor1.value).count() == 1;
+    }
+
+    public boolean isValidEquation(int equation) {
+        return Arrays.stream(Equation.values()).filter(equation1 -> equation == equation1.value).count() == 1;
+    }
+
+    public enum Equation {
+        ADD(GL14.GL_FUNC_ADD),
+        SUBTRACT(GL14.GL_FUNC_SUBTRACT),
+        REVERSE_SUBTRACT(GL14.GL_FUNC_REVERSE_SUBTRACT),
+        MIN(GL14.GL_MIN),
+        MAX(GL14.GL_MAX);
+
+        public final int value;
+
+        Equation(int value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blender.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blender.java
@@ -11,16 +11,16 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 public class Blender {
-    public static final Blender DEFAULT = new Blender(false, -1, -1, -1, -1, -1, false, false, false, true);
+    public static final Blender DEFAULT = new Blender(false, 770, 1, 32774, 0, 0, false, false, false, true);
     public static final Blender DECORATIONS = new Blender(true, 770, 1, 32774, 1, 0, false, false, false, true);
 
     public static Codec<Blender> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.BOOL.optionalFieldOf("separateFunction", false).forGetter(Blender::isSeparateFunction),
-            Codec.INT.optionalFieldOf("sourceFactor", -1).forGetter(Blender::getsFactor),
-            Codec.INT.optionalFieldOf("destinationFactor", -1).forGetter(Blender::getdFactor),
-            Codec.INT.optionalFieldOf("equation", -1).forGetter(Blender::getEquation),
-            Codec.INT.optionalFieldOf("sourceFactorAlpha", -1).forGetter(Blender::getsFactor2),
-            Codec.INT.optionalFieldOf("destinationFactorAlpha", -1).forGetter(Blender::getDestinationFactorAlpha),
+            Codec.INT.optionalFieldOf("sourceFactor", 770).forGetter(Blender::getSourceFactor),
+            Codec.INT.optionalFieldOf("destinationFactor", 1).forGetter(Blender::getDestinationFactor),
+            Codec.INT.optionalFieldOf("equation", 32774).forGetter(Blender::getEquation),
+            Codec.INT.optionalFieldOf("sourceFactorAlpha", 0).forGetter(Blender::getSourceFactorAlpha),
+            Codec.INT.optionalFieldOf("destinationFactorAlpha", 0).forGetter(Blender::getDestinationFactorAlpha),
             Codec.BOOL.optionalFieldOf("redAlphaEnabled", false).forGetter(Blender::isRedAlphaEnabled),
             Codec.BOOL.optionalFieldOf("greenAlphaEnabled", false).forGetter(Blender::isGreenAlphaEnabled),
             Codec.BOOL.optionalFieldOf("blueAlphaEnabled", false).forGetter(Blender::isBlueAlphaEnabled),
@@ -29,8 +29,8 @@ public class Blender {
 
     private final boolean separateFunction;
 
-    private final int sFactor;
-    private final int dFactor;
+    private final int sourceFactor;
+    private final int destinationFactor;
     private final int equation;
 
     private final int sourceFactorAlpha;
@@ -43,10 +43,10 @@ public class Blender {
 
     private final Consumer<Float> blendFunc;
 
-    public Blender(boolean separateFunction, int sFactor, int dFactor, int equation, int sourceFactorAlpha, int destinationFactorAlpha, boolean redAlphaEnabled, boolean greenAlphaEnabled, boolean blueAlphaEnabled, boolean alphaEnabled) {
+    public Blender(boolean separateFunction, int sourceFactor, int destinationFactor, int equation, int sourceFactorAlpha, int destinationFactorAlpha, boolean redAlphaEnabled, boolean greenAlphaEnabled, boolean blueAlphaEnabled, boolean alphaEnabled) {
         this.separateFunction = separateFunction;
-        this.sFactor = sFactor;
-        this.dFactor = dFactor;
+        this.sourceFactor = sourceFactor;
+        this.destinationFactor = destinationFactor;
         this.equation = equation;
         this.sourceFactorAlpha = sourceFactorAlpha;
         this.destinationFactorAlpha = destinationFactorAlpha;
@@ -55,17 +55,18 @@ public class Blender {
         this.blueAlphaEnabled = blueAlphaEnabled;
         this.alphaEnabled = alphaEnabled;
 
-        if ((this.separateFunction && this.isValidFactor(sFactor) && this.isValidFactor(dFactor) && this.isValidFactor(sourceFactorAlpha) && this.isValidFactor(destinationFactorAlpha) && this.isValidEquation(equation)) || (this.isValidFactor(sFactor) && this.isValidFactor(dFactor) && this.isValidEquation(equation))) {
+        if ((this.separateFunction && this.isValidFactor(sourceFactor) && this.isValidFactor(destinationFactor) && this.isValidFactor(sourceFactorAlpha) && this.isValidFactor(destinationFactorAlpha) && this.isValidEquation(equation)) || (this.isValidFactor(sourceFactor) && this.isValidFactor(destinationFactor) && this.isValidEquation(equation))) {
             this.blendFunc = (alpha) -> {
                 if (this.separateFunction) {
-                    RenderSystem.blendFuncSeparate(this.sFactor, this.dFactor, this.sourceFactorAlpha, this.destinationFactorAlpha);
+                    RenderSystem.blendFuncSeparate(this.sourceFactor, this.destinationFactor, this.sourceFactorAlpha, this.destinationFactorAlpha);
                 } else {
-                    RenderSystem.blendFunc(this.sFactor, this.dFactor);
+                    RenderSystem.blendFunc(this.sourceFactor, this.destinationFactor);
                 }
                 RenderSystem.blendEquation(this.equation);
                 RenderSystem.setShaderColor(this.redAlphaEnabled ? alpha : 1.0F, this.greenAlphaEnabled ? alpha : 1.0F, this.blueAlphaEnabled ? alpha : 1.0F, this.alphaEnabled ? alpha : 1.0F);
             };
         } else {
+            FabricSkyBoxesClient.getLogger().error("Invalid custom blender values!");
             this.blendFunc = (alpha) -> {
                 RenderSystem.defaultBlendFunc();
                 RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);
@@ -81,19 +82,19 @@ public class Blender {
         return separateFunction;
     }
 
-    public int getsFactor() {
-        return sFactor;
+    public int getSourceFactor() {
+        return sourceFactor;
     }
 
-    public int getdFactor() {
-        return dFactor;
+    public int getDestinationFactor() {
+        return destinationFactor;
     }
 
     public int getEquation() {
         return equation;
     }
 
-    public int getsFactor2() {
+    public int getSourceFactorAlpha() {
         return sourceFactorAlpha;
     }
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blender.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Blender.java
@@ -66,7 +66,6 @@ public class Blender {
                 RenderSystem.setShaderColor(this.redAlphaEnabled ? alpha : 1.0F, this.greenAlphaEnabled ? alpha : 1.0F, this.blueAlphaEnabled ? alpha : 1.0F, this.alphaEnabled ? alpha : 1.0F);
             };
         } else {
-            FabricSkyBoxesClient.getLogger().error("Invalid blend factors/equations in custom blender!");
             this.blendFunc = (alpha) -> {
                 RenderSystem.defaultBlendFunc();
                 RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, alpha);

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
@@ -18,23 +18,26 @@ public class Decorations {
             Codec.BOOL.optionalFieldOf("showSun", false).forGetter(Decorations::isSunEnabled),
             Codec.BOOL.optionalFieldOf("showMoon", false).forGetter(Decorations::isMoonEnabled),
             Codec.BOOL.optionalFieldOf("showStars", false).forGetter(Decorations::isStarsEnabled),
-            Rotation.CODEC.optionalFieldOf("rotation", Rotation.DEFAULT).forGetter(Decorations::getRotation)
+            Rotation.CODEC.optionalFieldOf("rotation", Rotation.DEFAULT).forGetter(Decorations::getRotation),
+            Blend.CODEC.optionalFieldOf("blend", Blend.DECORATIONS).forGetter(Decorations::getBlend)
     ).apply(instance, Decorations::new));
-    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, Rotation.DEFAULT);
+    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, Rotation.DEFAULT, Blend.DECORATIONS);
     private final Identifier sunTexture;
     private final Identifier moonTexture;
     private final boolean sunEnabled;
     private final boolean moonEnabled;
     private final boolean starsEnabled;
     private final Rotation rotation;
+    private final Blend blend;
 
-    public Decorations(Identifier sun, Identifier moon, boolean sunEnabled, boolean moonEnabled, boolean starsEnabled, Rotation rotation) {
+    public Decorations(Identifier sun, Identifier moon, boolean sunEnabled, boolean moonEnabled, boolean starsEnabled, Rotation rotation, Blend blend) {
         this.sunTexture = sun;
         this.moonTexture = moon;
         this.sunEnabled = sunEnabled;
         this.moonEnabled = moonEnabled;
         this.starsEnabled = starsEnabled;
         this.rotation = rotation;
+        this.blend = blend;
     }
 
     public Identifier getSunTexture() {
@@ -59,5 +62,9 @@ public class Decorations {
 
     public Rotation getRotation() {
         return rotation;
+    }
+
+    public Blend getBlend() {
+        return blend;
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
@@ -15,7 +15,7 @@ public class Decorations {
     public static final Codec<Decorations> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Identifier.CODEC.optionalFieldOf("sun", SUN).forGetter(Decorations::getSunTexture),
             Identifier.CODEC.optionalFieldOf("moon", MOON_PHASES).forGetter(Decorations::getMoonTexture),
-            Codec.BOOL.optionalFieldOf("showVanillaSky", false).forGetter(Decorations::isSunEnabled),
+            Codec.BOOL.optionalFieldOf("showVanillaSky", false).forGetter(Decorations::isVanillaSkyEnabled),
             Codec.BOOL.optionalFieldOf("showSun", false).forGetter(Decorations::isSunEnabled),
             Codec.BOOL.optionalFieldOf("showMoon", false).forGetter(Decorations::isMoonEnabled),
             Codec.BOOL.optionalFieldOf("showStars", false).forGetter(Decorations::isStarsEnabled),

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
@@ -15,12 +15,12 @@ public class Decorations {
     public static final Codec<Decorations> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Identifier.CODEC.optionalFieldOf("sun", SUN).forGetter(Decorations::getSunTexture),
             Identifier.CODEC.optionalFieldOf("moon", MOON_PHASES).forGetter(Decorations::getMoonTexture),
-            Codec.BOOL.optionalFieldOf("showSun", true).forGetter(Decorations::isSunEnabled),
-            Codec.BOOL.optionalFieldOf("showMoon", true).forGetter(Decorations::isMoonEnabled),
-            Codec.BOOL.optionalFieldOf("showStars", true).forGetter(Decorations::isStarsEnabled),
+            Codec.BOOL.optionalFieldOf("showSun", false).forGetter(Decorations::isSunEnabled),
+            Codec.BOOL.optionalFieldOf("showMoon", false).forGetter(Decorations::isMoonEnabled),
+            Codec.BOOL.optionalFieldOf("showStars", false).forGetter(Decorations::isStarsEnabled),
             Rotation.CODEC.optionalFieldOf("rotation", Rotation.DEFAULT).forGetter(Decorations::getRotation)
     ).apply(instance, Decorations::new));
-    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, true, true, true, Rotation.DEFAULT);
+    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, Rotation.DEFAULT);
     private final Identifier sunTexture;
     private final Identifier moonTexture;
     private final boolean sunEnabled;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
@@ -15,24 +15,27 @@ public class Decorations {
     public static final Codec<Decorations> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Identifier.CODEC.optionalFieldOf("sun", SUN).forGetter(Decorations::getSunTexture),
             Identifier.CODEC.optionalFieldOf("moon", MOON_PHASES).forGetter(Decorations::getMoonTexture),
+            Codec.BOOL.optionalFieldOf("showVanillaSky", false).forGetter(Decorations::isSunEnabled),
             Codec.BOOL.optionalFieldOf("showSun", false).forGetter(Decorations::isSunEnabled),
             Codec.BOOL.optionalFieldOf("showMoon", false).forGetter(Decorations::isMoonEnabled),
             Codec.BOOL.optionalFieldOf("showStars", false).forGetter(Decorations::isStarsEnabled),
             Rotation.CODEC.optionalFieldOf("rotation", Rotation.DEFAULT).forGetter(Decorations::getRotation),
             Blend.CODEC.optionalFieldOf("blend", Blend.DECORATIONS).forGetter(Decorations::getBlend)
     ).apply(instance, Decorations::new));
-    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, Rotation.DEFAULT, Blend.DECORATIONS);
+    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, false, Rotation.DEFAULT, Blend.DECORATIONS);
     private final Identifier sunTexture;
     private final Identifier moonTexture;
+    private final boolean vanillaSkyEnabled;
     private final boolean sunEnabled;
     private final boolean moonEnabled;
     private final boolean starsEnabled;
     private final Rotation rotation;
     private final Blend blend;
 
-    public Decorations(Identifier sun, Identifier moon, boolean sunEnabled, boolean moonEnabled, boolean starsEnabled, Rotation rotation, Blend blend) {
+    public Decorations(Identifier sun, Identifier moon, boolean vanillaSkyEnabled, boolean sunEnabled, boolean moonEnabled, boolean starsEnabled, Rotation rotation, Blend blend) {
         this.sunTexture = sun;
         this.moonTexture = moon;
+        this.vanillaSkyEnabled = vanillaSkyEnabled;
         this.sunEnabled = sunEnabled;
         this.moonEnabled = moonEnabled;
         this.starsEnabled = starsEnabled;
@@ -46,6 +49,10 @@ public class Decorations {
 
     public Identifier getMoonTexture() {
         return this.moonTexture;
+    }
+
+    public boolean isVanillaSkyEnabled() {
+        return vanillaSkyEnabled;
     }
 
     public boolean isSunEnabled() {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Decorations.java
@@ -15,27 +15,24 @@ public class Decorations {
     public static final Codec<Decorations> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Identifier.CODEC.optionalFieldOf("sun", SUN).forGetter(Decorations::getSunTexture),
             Identifier.CODEC.optionalFieldOf("moon", MOON_PHASES).forGetter(Decorations::getMoonTexture),
-            Codec.BOOL.optionalFieldOf("showVanillaSky", false).forGetter(Decorations::isVanillaSkyEnabled),
             Codec.BOOL.optionalFieldOf("showSun", false).forGetter(Decorations::isSunEnabled),
             Codec.BOOL.optionalFieldOf("showMoon", false).forGetter(Decorations::isMoonEnabled),
             Codec.BOOL.optionalFieldOf("showStars", false).forGetter(Decorations::isStarsEnabled),
             Rotation.CODEC.optionalFieldOf("rotation", Rotation.DEFAULT).forGetter(Decorations::getRotation),
             Blend.CODEC.optionalFieldOf("blend", Blend.DECORATIONS).forGetter(Decorations::getBlend)
     ).apply(instance, Decorations::new));
-    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, false, Rotation.DEFAULT, Blend.DECORATIONS);
+    public static final Decorations DEFAULT = new Decorations(SUN, MOON_PHASES, false, false, false, Rotation.DEFAULT, Blend.DECORATIONS);
     private final Identifier sunTexture;
     private final Identifier moonTexture;
-    private final boolean vanillaSkyEnabled;
     private final boolean sunEnabled;
     private final boolean moonEnabled;
     private final boolean starsEnabled;
     private final Rotation rotation;
     private final Blend blend;
 
-    public Decorations(Identifier sun, Identifier moon, boolean vanillaSkyEnabled, boolean sunEnabled, boolean moonEnabled, boolean starsEnabled, Rotation rotation, Blend blend) {
+    public Decorations(Identifier sun, Identifier moon, boolean sunEnabled, boolean moonEnabled, boolean starsEnabled, Rotation rotation, Blend blend) {
         this.sunTexture = sun;
         this.moonTexture = moon;
-        this.vanillaSkyEnabled = vanillaSkyEnabled;
         this.sunEnabled = sunEnabled;
         this.moonEnabled = moonEnabled;
         this.starsEnabled = starsEnabled;
@@ -49,10 +46,6 @@ public class Decorations {
 
     public Identifier getMoonTexture() {
         return this.moonTexture;
-    }
-
-    public boolean isVanillaSkyEnabled() {
-        return vanillaSkyEnabled;
     }
 
     public boolean isSunEnabled() {

--- a/src/main/resources/fabricskyboxes.mixins.json
+++ b/src/main/resources/fabricskyboxes.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
   ],
   "client": [
+    "skybox.BackgroundRendererMixin",
     "skybox.FogColorMixin",
     "skybox.SkyboxRenderMixin",
     "skybox.SunSkyColorMixin",

--- a/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
+++ b/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
@@ -51,7 +51,8 @@ public class SkyboxGenerationTest {
                 true,
                 true,
                 false,
-                Rotation.DEFAULT
+                Rotation.DEFAULT,
+                Blend.DECORATIONS
         );
 
         Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().setLenient().create();

--- a/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
+++ b/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
@@ -48,6 +48,7 @@ public class SkyboxGenerationTest {
         Decorations decorations = new Decorations(
                 PlayerScreenHandler.BLOCK_ATLAS_TEXTURE,
                 SpriteAtlasTexture.PARTICLE_ATLAS_TEXTURE,
+                false,
                 true,
                 true,
                 false,

--- a/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
+++ b/src/test/java/io/github/amerebagatelle/fabricskyboxes/tests/SkyboxGenerationTest.java
@@ -48,7 +48,6 @@ public class SkyboxGenerationTest {
         Decorations decorations = new Decorations(
                 PlayerScreenHandler.BLOCK_ATLAS_TEXTURE,
                 SpriteAtlasTexture.PARTICLE_ATLAS_TEXTURE,
-                false,
                 true,
                 true,
                 false,

--- a/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
+++ b/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
@@ -26,7 +26,8 @@ public class TestClientModInitializer implements ClientModInitializer {
                 true,
                 true,
                 false,
-                Rotation.DEFAULT
+                Rotation.DEFAULT,
+                Blend.DECORATIONS
         );
         CONDITIONS = new Conditions.Builder()
                 .biomes(new Identifier("minecraft:plains"))

--- a/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
+++ b/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
@@ -23,6 +23,7 @@ public class TestClientModInitializer implements ClientModInitializer {
         DECORATIONS = new Decorations(
                 PlayerScreenHandler.BLOCK_ATLAS_TEXTURE,
                 SpriteAtlasTexture.PARTICLE_ATLAS_TEXTURE,
+                false,
                 true,
                 true,
                 false,

--- a/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
+++ b/src/testmod/java/io/github/amerebagatelle/fabricskyboxes/TestClientModInitializer.java
@@ -23,7 +23,6 @@ public class TestClientModInitializer implements ClientModInitializer {
         DECORATIONS = new Decorations(
                 PlayerScreenHandler.BLOCK_ATLAS_TEXTURE,
                 SpriteAtlasTexture.PARTICLE_ATLAS_TEXTURE,
-                false,
                 true,
                 true,
                 false,


### PR DESCRIPTION
## Refactor Summary
This PR improves the decorations system by enabling each decoration to be rendered separately. Previously, decorations could only be declared in one skybox, meaning that it was impossible to place sun/moon/stars separately.

![Illustration by UsernameGeri](https://user-images.githubusercontent.com/30311066/225610740-6e89144c-1ea5-431d-b463-6e7671bf95a5.png)
Illustration of changes (Courtesy of @UsernameGeri)

## Motivation
The motivation behind these changes is to provide greater flexibility and customization options for users when designing skyboxes. By allowing decorations to be rendered separately, users will have the ability to place sun, moon, and stars wherever they choose, resulting in more unique and creative skyboxes. This will ultimately enhance the user experience and improve the overall quality of the game. 
