### PR TITLE
Iris API/sun path rotation support

### DIFF
--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/IrisCompat.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/IrisCompat.java
@@ -1,0 +1,35 @@
+package io.github.amerebagatelle.fabricskyboxes;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.InvocationTargetException;
+
+public class IrisCompat {
+    private static boolean isIrisPresent;
+    private static MethodHandle handle;
+    private static Object apiInstance;
+
+    static {
+        try {
+            Class<?> api = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            apiInstance = api.cast(api.getDeclaredMethod("getInstance").invoke(null));
+            handle = MethodHandles.lookup().findVirtual(api, "getSunPathRotation", MethodType.methodType(float.class));
+            isIrisPresent = true;
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            isIrisPresent = false;
+        }
+    }
+
+    public static float getSunPathRotation() {
+        if (isIrisPresent) {
+            try {
+                return (float) handle.invoke(apiInstance);
+            } catch (Throwable throwable) {
+                throwable.printStackTrace();
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -2,6 +2,7 @@ package io.github.amerebagatelle.fabricskyboxes.skyboxes;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+import io.github.amerebagatelle.fabricskyboxes.IrisCompat;
 import io.github.amerebagatelle.fabricskyboxes.SkyboxManager;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.FSBSkybox;
 import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
@@ -255,6 +256,7 @@ public abstract class AbstractSkybox implements FSBSkybox {
             matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rotationAxis.y()));
             matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(rotationAxis.z()));
             matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
+            matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(IrisCompat.getSunPathRotation()));
             matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(world.getSkyAngle(tickDelta) * 360.0F * decorations.getRotation().getRotationSpeed()));
             matrices.multiply(RotationAxis.NEGATIVE_Z.rotationDegrees(rotationAxis.z()));
             matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(rotationAxis.y()));

--- a/src/testmod/resources/fabric.mod.json
+++ b/src/testmod/resources/fabric.mod.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "environment": "client",
   "depends": {
-    "minecraft": "1.19",
+    "minecraft": "1.19.4",
     "fabricskyboxes": "*"
   }
 }


### PR DESCRIPTION
Uses smart reflection, and does not leave any errors if there is no API or Iris is missing.

This will only work with Iris 1.6, Iris 1.5 will have no effect.