### PR TITLE
Schema V3

### DIFF
--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -608,7 +608,7 @@ Stores a list of four integers which specify the time in ticks to start and end 
 
 Specifies a minimum and maximum x/y/z value. All fields are required.
 
-**Specification**'
+**Specification**
 
 | Name  |    Datatype    |              Description               |
 |:-----:|:--------------:|:--------------------------------------:|

--- a/docs/schema-v3-proposal/decorations.md
+++ b/docs/schema-v3-proposal/decorations.md
@@ -1,3 +1,5 @@
+# Decorations
+
 ```json5
 {
   "sun": {

--- a/docs/schema-v3-proposal/decorations.md
+++ b/docs/schema-v3-proposal/decorations.md
@@ -1,23 +1,56 @@
 # Decorations
 
-```json5
+## Decoration Objects
+
+### Decoration
+
+Defines the state of a decoration.
+
+**Specification**
+
+| Name      | Datatype                              | Description                                | Required           | Default Value                                  |
+|-----------|---------------------------------------|--------------------------------------------|--------------------|------------------------------------------------|
+| `visible` | Boolean                               | Whether the decoration should render.      | :white_check_mark: |                                                |
+| `texture` | [Identifier](schema-v3.md#identifier) | The texture to be used for the decoration. | :x:                | `"minecraft:textures/environment/element.png"` |
+
+**Example**
+
+```json
+{
+  "visible": true,
+  "texture": "minecraft:textures/environment/sun.png"
+}
+```
+
+## Decorations
+
+Defines the state of the sun, moon, and stars.
+
+**Specification**
+
+| Name          | Datatype                  | Description                                 | Required           |
+|---------------|---------------------------|---------------------------------------------|--------------------|
+| `sun`         | [Decoration](#decoration) | Describes the sun.                          | :white_check_mark: |
+| `moon_phases` | [Decoration](#decoration) | Describes the moon phases.                  | :white_check_mark: |
+| `stars`       | [Decoration](#decoration) | Describes the stars.  Textures do not work. | :white_check_mark: |
+
+**Example**
+
+```json
 {
   "sun": {
     "visible": true,
-    "path": "minecraft:sun",
+    "texture": "minecraft:sun",
     "rotation": {
       "static": [],
       "axis": []
     }
   },
-  "moon": {
+  "moon_phases": {
     "visible": false
   },
   "stars": {
-    "visible": true,
-    "rendering": { // might be an interesting block to play with... unsure if it's worth it though
-      
-    }
+    "visible": true
   }
 }
 ```

--- a/docs/schema-v3-proposal/decorations.md
+++ b/docs/schema-v3-proposal/decorations.md
@@ -1,0 +1,21 @@
+```json5
+{
+  "sun": {
+    "visible": true,
+    "path": "minecraft:sun",
+    "rotation": {
+      "static": [],
+      "axis": []
+    }
+  },
+  "moon": {
+    "visible": false
+  },
+  "stars": {
+    "visible": true,
+    "rendering": { // might be an interesting block to play with... unsure if it's worth it though
+      
+    }
+  }
+}
+```

--- a/docs/schema-v3-proposal/fog.md
+++ b/docs/schema-v3-proposal/fog.md
@@ -1,5 +1,16 @@
 # Fog
 
+Defines the displayed fog.
+
+**Specification**
+
+| Name         | Description                                                          | Required           |
+|--------------|----------------------------------------------------------------------|--------------------|
+| `thickFog`   | Specifies whether the fog should be thick.                           | :white_check_mark: |
+| `color`      | Specifies the color of the fog.                                      | :white_check_mark: |
+| `sunSkyTint` | Specifies whether the sun tints the sky yellow at sunrise and sunset | :white_check_mark: |
+
+
 ```json5
 {
   "thickFog": true,

--- a/docs/schema-v3-proposal/fog.md
+++ b/docs/schema-v3-proposal/fog.md
@@ -1,0 +1,7 @@
+```json5
+{
+  "thickFog": true,
+  "color": [0, 255, 0, 255], // rgba, 0-255
+  "sunSkyTint": false // sun tint yellow (perhaps better for skybox?)
+}
+```

--- a/docs/schema-v3-proposal/fog.md
+++ b/docs/schema-v3-proposal/fog.md
@@ -1,3 +1,5 @@
+# Fog
+
 ```json5
 {
   "thickFog": true,

--- a/docs/schema-v3-proposal/images.md
+++ b/docs/schema-v3-proposal/images.md
@@ -1,0 +1,3 @@
+# Images
+
+Images must be files loadable by Minecraft.  They may be any size, however square sizes are recommended.

--- a/docs/schema-v3-proposal/images.md
+++ b/docs/schema-v3-proposal/images.md
@@ -1,3 +1,4 @@
 # Images
 
 Images must be files loadable by Minecraft.  They may be any size, however square sizes are recommended.
+The folder for images is a convenience.  Textures are accessed by their identifiers, like in the base game files.

--- a/docs/schema-v3-proposal/schema-v3.md
+++ b/docs/schema-v3-proposal/schema-v3.md
@@ -32,17 +32,21 @@ The details for the files in each of the subfolders can be found in their respec
 
 ```json5
 {
-  "skyboxes": [
+  "layers": [
     {
       "file": "skybox1.json",
-      "type": "square-textured"
+      "type": "square-textured",
+      "conditions": {
+        "biomes": [] 
+      }
     },
-  ],
-  "decorations": [
     {
       "file": "decorations.json",
-      "when": "skybox1.json" // optional - active at all times unless specified
-    },
+      "type": "decorations",
+      "conditions": {
+        "skybox": "skybox1"
+      }
+    }
   ],
   "fog": [
     "fog.json"

--- a/docs/schema-v3-proposal/schema-v3.md
+++ b/docs/schema-v3-proposal/schema-v3.md
@@ -1,11 +1,12 @@
 # Schema V3
 
-This specification aims to set a standard for custom sky rendering.  
+This specification is the standard for sky rendering in FabricSkyboxes
 This schema envelops the entire file structure of a resource pack being used to load skyboxes.
+There are no promises about breaking this for the next few versions.
 
 ## File Structure
 
-The basic structure of a resource pack implementing custom skyboxes will be as follows:
+The basic structure of a resource pack implementing custom skyboxes is as follows:
 
 ```
 assets/namespace/sky...
@@ -69,8 +70,6 @@ Contains a list of four floats representing a RGBA color.
 }
 ```
 
-### Fade
-
 ### Range
 
 Specifies a range of values.
@@ -90,7 +89,42 @@ Defined as an array of two numbers, where the first is the minimum and the secon
 ```
 
 ### Rotation
+
 TODO
+
+### Fade
+
+Stores a list of four integers which specify the time in ticks to start and end fading the skybox in and out.
+If 0 is specified for all values, the fade will be at full opacity at all times.
+
+**Specification**
+
+|      Name      | Datatype |                       Description                       |      Required      | Default |
+|:--------------:|:--------:|:-------------------------------------------------------:|:------------------:|:-------:|
+| `startFadeIn`  | Integer  | The times in ticks when a skybox will start to fade in  | :white_check_mark: |    -    |
+|  `endFadeIn`   | Integer  |   The times in ticks when a skybox will end fading in   | :white_check_mark: |    -    |
+| `startFadeOut` | Integer  | The times in ticks when a skybox will start to fade out | :white_check_mark: |    -    |
+|  `endFadeOut`  | Integer  |  The times in ticks when a skybox will end fading out   | :white_check_mark: |    -    |
+
+**Conversion Table**
+
+| Time in Ticks | Clock Time |
+|:-------------:|:----------:|
+|       0       |    6 AM    |
+|     6000      |   12 PM    |
+|     12000     |    6 PM    |
+|     18000     |   12 AM    |
+
+**Example**
+
+```json
+{
+  "startFadeIn": 1000,
+  "endFadeIn": 2000,
+  "startFadeOut": 3000,
+  "endFadeOut": 4000
+}
+```
 
 ### Weather
 
@@ -143,6 +177,7 @@ May contain values of any type, represented by "Value" in specification.
 
 **Example**
 With Value being an [Identifier](#identifier).
+
 ```json
 {
   "whitelist": [
@@ -245,11 +280,12 @@ Describes a skybox layer.
 
 **Specification**
 
-| Name         | Datatype                  | Description                               | Required           |
-|--------------|---------------------------|-------------------------------------------|--------------------|
-| `file`       | [Identifier](#identifier) | The file to reference for the layer data. | :white_check_mark: |
-| `type`       | [Layer Type](#layer-type) | The type of the layer.                    | :white_check_mark: |
-| `conditions` | [Conditions](#conditions) | The conditions for the layer.             | :white_check_mark: |
+| Name         | Datatype                  | Description                                         | Required           |
+|--------------|---------------------------|-----------------------------------------------------|--------------------|
+| `file`       | [Identifier](#identifier) | The file to reference for the layer data.           | :white_check_mark: |
+| `type`       | [Layer Type](#layer-type) | The type of the layer.                              | :white_check_mark: |
+| `conditions` | [Conditions](#conditions) | The conditions for the layer.                       | :white_check_mark: |
+| `fade`       | [Fade](#fade)             | The timing of the layer appearing and disappearing, | :white_check_mark: |
 
 **Example**
 
@@ -258,10 +294,15 @@ Describes a skybox layer.
   "file": "skybox1.json",
   "type": "square-textured",
   "conditions": {
+  },
+  "fade": {
+    "startFadeIn": 0,
+    "endFadeIn": 0,
+    "startFadeOut": 0,
+    "endFadeOut": 0
   }
 }
 ```
-
 
 ## Skybox Configuration JSON
 
@@ -272,8 +313,7 @@ This file's purpose is to handle all interactions between skyboxes and when the 
 | Name   | Datatype              | Description                                                                                                    | Required           |
 |--------|-----------------------|----------------------------------------------------------------------------------------------------------------|--------------------|
 | Layers | [Layer](#layer) Array | Defines priority of layers being rendered.  Layers will be rendered with the first object in the array on top. | :white_check_mark: |
-| Fog    | String Array          | Defines fog.  Valid values reference [Fog](#fog.md) files.                                                     | :white_check_mark: |
-
+| Fog    | [Layer](#layer) Array | Defines fog.                                                                                                   | :white_check_mark: |
 
 **Example**
 
@@ -285,6 +325,12 @@ This file's purpose is to handle all interactions between skyboxes and when the 
       "type": "square-textured",
       "conditions": {
         "biomes": []
+      },
+      "fade": {
+        "startFadeIn": 0,
+        "endFadeIn": 0,
+        "startFadeOut": 0,
+        "endFadeOut": 0
       }
     },
     {
@@ -292,6 +338,12 @@ This file's purpose is to handle all interactions between skyboxes and when the 
       "type": "decorations",
       "conditions": {
         "skybox": "skybox1"
+      },
+      "fade": {
+        "startFadeIn": 0,
+        "endFadeIn": 0,
+        "startFadeOut": 0,
+        "endFadeOut": 0
       }
     }
   ],

--- a/docs/schema-v3-proposal/schema-v3.md
+++ b/docs/schema-v3-proposal/schema-v3.md
@@ -6,6 +6,7 @@ This schema envelops the entire file structure of a resource pack being used to 
 ## File Structure
 
 The basic structure of a resource pack implementing custom skyboxes will be as follows:
+
 ```
 assets/namespace/sky...
     /skyboxes.json
@@ -22,13 +23,259 @@ assets/namespace/sky...
 The overarching `skyboxes.json` file will define the layer priority for all skyboxes.
 It also defines several general conflict resolution strategies for multiple skyboxes.
 
-The details for the files in each of the subfolders can be found in their respectively named docs:
-- skybox.md
-- decorations.md
-- fog.md
-- images.md
+The details for the files in each of the sub-folders can be found in their respectively named docs:
+
+- [Skyboxes](skybox.md)
+- [Decorations](decorations.md)
+- [Fog](fog.md)
+- [Images](images.md)
+
+## Objects
+
+This section defines all common objects and their data structures.  
+When a common object is referenced, it is guaranteed to be parsed as described in this section.
+
+### Identifier
+
+Specifies the location of a file as a string in the format `namespace:path`. The string `namespace:path` translates
+to `assets/namespace/path` (at least in the scenarios present in FabricSkyboxes). More info can be found on
+the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Resource_location).
+
+**Specification**
+
+Does not contain any fields. The value must consist of a valid namespace and path, separated by a colon (`:`)
+
+### RGBA
+
+Contains a list of four floats representing a RGBA color.
+
+**Specification**
+
+|  Name   | Datatype |                                    Description                                     |      Required      | Default |
+|:-------:|:--------:|:----------------------------------------------------------------------------------:|:------------------:|:-------:|
+|  `red`  |  Float   |  Specifies the amount of red color to be used. Must be a value between 0 and 255.  | :white_check_mark: |    -    |
+| `green` |  Float   | Specifies the amount of green color to be used. Must be a value between 0 and 255. | :white_check_mark: |    -    |
+| `blue`  |  Float   | Specifies the amount of blue color to be used. Must be a value between 0 and 255.  | :white_check_mark: |    -    |
+| `alpha` |  Float   |     Specifies the amount of alpha to be used. Must be a value between 0 and 1.     | :white_check_mark: |    -    |
+
+**Example**
+
+```json
+{
+  "red": 0,
+  "blue": 100,
+  "green": 255,
+  "alpha": 0.8
+}
+```
+
+### Fade
+
+### Range
+
+Specifies a range of values.
+
+**Specification**
+
+Does not contain any fields.
+Defined as an array of two numbers, where the first is the minimum and the second is the maximum.
+
+**Examples**
+
+```json
+[
+  60,
+  120
+]
+```
+
+### Rotation
+TODO
+
+### Weather
+
+Specifies a kind of weather as a String.
+
+**Specification**
+
+Does not contain any fields. The value must be one of `clear`, `rain`, `thunder` or `snow`.
+
+### Loop
+
+Specifies the loop condition.
+
+**Specification**
+
+|   Name   |       Datatype        |                   Description                    | Required |     Default Value      |
+|:--------:|:---------------------:|:------------------------------------------------:|:--------:|:----------------------:|
+|  `days`  |         Float         |      Specifies the number of days to loop.       |   :x:    |           7            |
+| `ranges` | [Range](#range) Array | Specifies the days where the skybox is rendered. |   :x:    | Empty Array (all days) |
+
+**Example**
+
+```json
+{
+  "days": 30.0,
+  "ranges": [
+    {
+      "min": 0,
+      "max": 7
+    },
+    {
+      "min": 14,
+      "max": 21
+    }
+  ]
+}
+```
+
+### Condition
+
+Represents a union of a whitelist and a blacklist.
+May contain values of any type, represented by "Value" in specification.
+
+**Specification**
+
+| Name        | Datatype    | Description                                                  | Required | Default Value |
+|-------------|-------------|--------------------------------------------------------------|----------|---------------|
+| `whitelist` | Value Array | Specifies a list of values that allow the condition to pass. | :x:      | Everything    |
+| `blacklist` | Value Array | Specifies a list of values that block the condition passing. | :x:      | None          |
+
+**Example**
+With Value being an [Identifier](#identifier).
+```json
+{
+  "whitelist": [
+    "minecraft:desert",
+    "minecraft:desert_hills"
+  ],
+  "blacklist": [
+    "minecraft:desert_lakes"
+  ]
+}
+```
+
+### Conditions
+
+Specifies when and where a layer should render. All fields are optional.
+
+**Specification**
+
+|     Name     |                     Datatype                      |                                 Description                                  |          Default value          |
+|:------------:|:-------------------------------------------------:|:----------------------------------------------------------------------------:|:-------------------------------:|
+|   `biomes`   | [Identifier](#identifier) [Condition](#condition) |       Specifies a list of biomes that the skybox should be rendered in       | Default [Condition](#condition) |
+|   `worlds`   | [Identifier](#identifier) [Condition](#condition) | Specifies a list of worlds sky effects that the skybox should be rendered in | Default [Condition](#condition) |
+| `dimensions` | [Identifier](#identifier) [Condition](#condition) |     Specifies a list of dimension that the skybox should be rendered in      | Default [Condition](#condition) |
+|  `effects`   | [Identifier](#identifier) [Condition](#condition) |      Specifies a list of effects that the skybox should be rendered in       | Default [Condition](#condition) |
+|  `weather`   |   [Weathers](#weather) [Condition](#condition)    | Specifies a list of weather conditions that the skybox should be rendered in | Default [Condition](#condition) |
+|  `xRanges`   |      [Range](#range) [Condition](#condition)      |  Specifies a list of coordinates that the skybox should be rendered between  | Default [Condition](#condition) |
+|  `yRanges`   |      [Range](#range) [Condition](#condition)      |  Specifies a list of coordinates that the skybox should be rendered between  | Default [Condition](#condition) |
+|  `zRanges`   |      [Range](#range) [Condition](#condition)      |  Specifies a list of coordinates that the skybox should be rendered between  | Default [Condition](#condition) |
+|    `loop`    |                   [Loop](#loop)                   |     Specifies the loop object that the skybox should be rendered between     |      Default [Loop](#loop)      |
+
+**Example**
+
+```json
+{
+  "biomes": [
+    "minecraft:desert",
+    "minecraft:desert_hills",
+    "minecraft:desert_lakes"
+  ],
+  "worlds": [
+    "minecraft:overworld"
+  ],
+  "dimensions": [
+    "my_datapack:custom_world"
+  ],
+  "effects": [
+    "minecraft:jump_boost",
+    "minecraft:speed",
+    "minecraft:slowness"
+  ],
+  "weather": [
+    "rain",
+    "thunder"
+  ],
+  "xRanges": [
+    {
+      "min": -100.0,
+      "max": 100.0
+    }
+  ],
+  "yRanges": [
+    {
+      "min": 50.0,
+      "max": 60.0
+    },
+    {
+      "min": 100.0,
+      "max": 110.0
+    }
+  ],
+  "zRanges": [
+    {
+      "min": -100.0,
+      "max": 100.0
+    }
+  ],
+  "loop": {
+    "days": 8,
+    "ranges": [
+      {
+        "min": 1,
+        "max": 7
+      }
+    ]
+  }
+}
+```
+
+### Layer Type
+
+Describes a layer type.
+
+**Specification**
+
+A string, with any valid skybox type or `decorations` for decorations layers.
+
+### Layer
+
+Describes a skybox layer.
+
+**Specification**
+
+| Name         | Datatype                  | Description                               | Required           |
+|--------------|---------------------------|-------------------------------------------|--------------------|
+| `file`       | [Identifier](#identifier) | The file to reference for the layer data. | :white_check_mark: |
+| `type`       | [Layer Type](#layer-type) | The type of the layer.                    | :white_check_mark: |
+| `conditions` | [Conditions](#conditions) | The conditions for the layer.             | :white_check_mark: |
+
+**Example**
+
+```json
+{
+  "file": "skybox1.json",
+  "type": "square-textured",
+  "conditions": {
+  }
+}
+```
+
 
 ## Skybox Configuration JSON
+
+This file's purpose is to handle all interactions between skyboxes and when the skyboxes should appear.
+
+**Specification**
+
+| Name   | Datatype              | Description                                                                                                    | Required           |
+|--------|-----------------------|----------------------------------------------------------------------------------------------------------------|--------------------|
+| Layers | [Layer](#layer) Array | Defines priority of layers being rendered.  Layers will be rendered with the first object in the array on top. | :white_check_mark: |
+| Fog    | String Array          | Defines fog.  Valid values reference [Fog](#fog.md) files.                                                     | :white_check_mark: |
+
+
+**Example**
 
 ```json5
 {
@@ -37,7 +284,7 @@ The details for the files in each of the subfolders can be found in their respec
       "file": "skybox1.json",
       "type": "square-textured",
       "conditions": {
-        "biomes": [] 
+        "biomes": []
       }
     },
     {
@@ -55,7 +302,10 @@ The details for the files in each of the subfolders can be found in their respec
 ```
 
 (Developer's Notes Below)
-The reason that the type is in the skybox description in the skyboxes.json is to facilitate easier parsing.
-Instead of having to get the metadata of the skybox and then parsing it again for the rest of the data - it can all be done once.
 
-The idea of the skyboxes.json file is that it defines what is being applied when and in what order, while the files themselves describe specific effects.
+The reason that the type is in the skybox description in the skyboxes.json is to facilitate easier parsing.
+Instead of having to get the metadata of the skybox and then parsing it again for the rest of the data - it can all be
+done once.
+
+The idea of the skyboxes.json file is that it defines what is being applied when and in what order, while the files
+themselves describe specific effects.

--- a/docs/schema-v3-proposal/schema-v3.md
+++ b/docs/schema-v3-proposal/schema-v3.md
@@ -1,0 +1,57 @@
+# Schema V3
+
+This specification aims to set a standard for custom sky rendering.  
+This schema envelops the entire file structure of a resource pack being used to load skyboxes.
+
+## File Structure
+
+The basic structure of a resource pack implementing custom skyboxes will be as follows:
+```
+assets/namespace/sky...
+    /skyboxes.json
+    /skyboxes/...
+        (all skybox JSON files here)
+    /decorations/...
+        (all decoration JSON files here)
+    /fog/
+        (all fog JSON files here)
+    /images/...
+        (all images here)
+```
+
+The overarching `skyboxes.json` file will define the layer priority for all skyboxes.
+It also defines several general conflict resolution strategies for multiple skyboxes.
+
+The details for the files in each of the subfolders can be found in their respectively named docs:
+- skybox.md
+- decorations.md
+- fog.md
+- images.md
+
+## Skybox Configuration JSON
+
+```json5
+{
+  "skyboxes": [
+    {
+      "file": "skybox1.json",
+      "type": "square-textured"
+    },
+  ],
+  "decorations": [
+    {
+      "file": "decorations.json",
+      "when": "skybox1.json" // optional - active at all times unless specified
+    },
+  ],
+  "fog": [
+    "fog.json"
+  ]
+}
+```
+
+(Developer's Notes Below)
+The reason that the type is in the skybox description in the skyboxes.json is to facilitate easier parsing.
+Instead of having to get the metadata of the skybox and then parsing it again for the rest of the data - it can all be done once.
+
+The idea of the skyboxes.json file is that it defines what is being applied when and in what order, while the files themselves describe specific effects.

--- a/docs/schema-v3-proposal/skybox.md
+++ b/docs/schema-v3-proposal/skybox.md
@@ -19,6 +19,10 @@ This is the base square texture format.
 | `top`    | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox up    | :white_check_mark: |
 | `bottom` | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox down  | :white_check_mark: |
 
+OR
+
+A individual [Identifier](schema-v3.md#identifier) representing a Optifine format texture.
+
 **Example**
 
 ```json

--- a/docs/schema-v3-proposal/skybox.md
+++ b/docs/schema-v3-proposal/skybox.md
@@ -1,41 +1,128 @@
 # Skyboxes
 
+Replaces the vanilla skybox with a different skybox.
+
+## Texture Objects
+
+### Square Texture
+
+This is the base square texture format.
+
+**Specification**
+
+| Name     | Datatype                              | Description                                                                      | Required           |
+|----------|---------------------------------------|----------------------------------------------------------------------------------|--------------------|
+| `north`  | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox north | :white_check_mark: |
+| `south`  | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox south | :white_check_mark: |
+| `east`   | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox east  | :white_check_mark: |
+| `west`   | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox west  | :white_check_mark: |
+| `top`    | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox up    | :white_check_mark: |
+| `bottom` | [Identifier](schema-v3.md#identifier) | Specifies the location of the texture to be used when rendering the skybox down  | :white_check_mark: |
+
+**Example**
+
+```json
+{
+  "north": "minecraft:textures/block/blue_ice.png",
+  "south": "minecraft:textures/block/blue_ice.png",
+  "east": "minecraft:textures/block/dark_oak_log.png",
+  "west": "minecraft:textures/block/dark_oak_log.png",
+  "top": "minecraft:textures/block/diamond_ore.png",
+  "bottom": "minecraft:textures/block/diamond_ore.png"
+}
+```
+
+## Texture
+
+This section specifies the texture object format for each type of skybox.
+
+### Square Textured Skybox
+
+A single-texture skybox of the type `square-textured`.
+
+**Specification**
+
+A single [Square Texture](#square-texture) object.
+
+### Animated Square Textured Skybox
+
+A multi-texture skybox of the type `animated-square-textured`.
+
+**Specification**
+
+| Name       | Datatype                                | Description                       | Required           |
+|------------|-----------------------------------------|-----------------------------------|--------------------|
+| `textures` | [Square Texture](#square-texture) Array | The array of textures to display. | :white_check_mark: |
+| `fps`      | Integer                                 | Frames per second for animation.  | :white_check_mark: |
+
+**Example**
+
+```json
+{
+  "textures": [
+    {
+      "north": "minecraft:textures/block/blue_ice.png",
+      "south": "minecraft:textures/block/blue_ice.png",
+      "east": "minecraft:textures/block/dark_oak_log.png",
+      "west": "minecraft:textures/block/dark_oak_log.png",
+      "top": "minecraft:textures/block/diamond_ore.png",
+      "bottom": "minecraft:textures/block/diamond_ore.png"
+    }
+  ],
+  "fps": 1
+}
+```
+
+## Textured Skybox
+
+All textured skybox types share this structure.
+
+**Specification**
+
+| Name       | Datatype                          | Description                                                   | Required           |
+|------------|-----------------------------------|---------------------------------------------------------------|--------------------|
+| `texture`  | [Texture](#texture)               | See textures object description.  Different for every type.   | :white_check_mark: |
+| `blend`    | [Blend](#blend)                   | Specifies how this skybox blends with other skyboxes.         | :white_check_mark: |
+| `rotation` | [Rotation](schema-v3.md#rotation) | Specifies how this skybox should rotate with the time of day. | :white_check_mark: |
+
 ```json5
 {
-  "conditions": { // playing with idea of putting this in main config json, for extra cool points
-    "biomes": {
-      "whitelist": [
-        
-      ],
-      "blacklist": [
-        
-      ]
+  "texture": {
+  },
+  "blend": {
+    "type": "",
+    // I still like this, low-effort defaults is good
+    "blender": {
+      // Maybe we only require one or the other - I think this is powerful, but usually not needed
     }
   },
-  "properties": {
-    "fade": { // Old fade object - minus the alwaysOn, find a way to express that via the numbers
-      
-    },
-    "maxAlpha": 0,
-    "transition": {
-      "in": 0,
-      "out": 0
-    }
-  },
-  "custom": { // everything that is type-specific goes in here
-    "textures": {
+  "rotation": {
+    // This needs a lot of work - as evidenced by the weeks of discussion about how confusing it is
+    "static": {},
+    "axis": {}
+  }
+}
+```
 
-    },
-    "blend": { // Discussion - type specific or not?
-      "type": "", // I still like this, low-effort defaults is good
-      "blender": { // Maybe we only require one or the other - I think this is powerful, but usually not needed
+## Monocolor Skybox
 
-      }
-    },
-    "rotation": { // This needs a lot of work - as evidenced by the weeks of discussion about how confusing it is
-      "static": {},
-      "axis": {}
-    }
+A single-color skybox of the type `monocolor`.
+
+**Specification**
+
+| Name    | Datatype                  | Description               | Required           |
+|---------|---------------------------|---------------------------|--------------------|
+| `color` | [RGBA](schema-v3.md#RGBA) | The color of this skybox. | :white_check_mark: |
+
+**Example**
+
+```json
+{
+  "color": {
+    "red": 0,
+    "blue": 100,
+    "green": 255,
+    "alpha": 1
   }
 }
 ```

--- a/docs/schema-v3-proposal/skybox.md
+++ b/docs/schema-v3-proposal/skybox.md
@@ -1,0 +1,39 @@
+```json5
+{
+  "conditions": { // playing with idea of putting this in main config json, for extra cool points
+    "biomes": {
+      "whitelist": [
+        
+      ],
+      "blacklist": [
+        
+      ]
+    }
+  },
+  "properties": {
+    "fade": { // Old fade object - minus the alwaysOn, find a way to express that via the numbers
+      
+    },
+    "maxAlpha": 0,
+    "transition": {
+      "in": 0,
+      "out": 0
+    }
+  },
+  "custom": { // everything that is type-specific goes in here
+    "textures": {
+
+    },
+    "blend": { // Discussion - type specific or not?
+      "type": "", // I still like this, low-effort defaults is good
+      "blender": { // Maybe we only require one or the other - I think this is powerful, but usually not needed
+
+      }
+    },
+    "rotation": { // This needs a lot of work - as evidenced by the weeks of discussion about how confusing it is
+      "static": {},
+      "axis": {}
+    }
+  }
+}
+```

--- a/docs/schema-v3-proposal/skybox.md
+++ b/docs/schema-v3-proposal/skybox.md
@@ -1,3 +1,5 @@
+# Skyboxes
+
 ```json5
 {
   "conditions": { // playing with idea of putting this in main config json, for extra cool points


### PR DESCRIPTION
Proposal for a Schema V3.

This schema proposal is built to allow easily defining multiple types of sky modifications separate from each other.  The multiplication of files will help organize sky features in more distinct groups.

Still in progress, definitely needs a lot longer before it's good.  Putting the concept out for review, however.