### PR TITLE
[Experimental] Add MultiTexture Skybox

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 
     modRuntimeOnly "maven.modrinth:lazydfu:0.1.3"
+    modRuntimeOnly "maven.modrinth:lithium:mc1.20.1-0.11.2"
+    modRuntimeOnly "maven.modrinth:sodium:mc1.20.1-0.5.3"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     modRuntimeOnly "maven.modrinth:lazydfu:0.1.3"
     modRuntimeOnly "maven.modrinth:lithium:mc1.20.1-0.11.2"
-    modRuntimeOnly "maven.modrinth:sodium:mc1.20.1-0.5.3"
+    modRuntimeOnly "maven.modrinth:sodium:mc1.20.1-0.5.2"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'

--- a/docs/schema-v2.md
+++ b/docs/schema-v2.md
@@ -22,6 +22,7 @@ This specification defines a format for a set of rules for the purpose of custom
     - [Animated](#animated-skyboxes)
     - [`animated-square-textured`](#animated-square-textured-skybox)
     - [`single-sprite-animated-square-textured`](#single-sprite-animated-square-textured-skybox)
+    - [`multi-texture`](#multi-texture-skybox)
 - [Data Types](#data-types)
     - [Properties Object](#properties-object)
     - [Conditions Object](#conditions-object)
@@ -38,6 +39,8 @@ This specification defines a format for a set of rules for the purpose of custom
     - [Blend Object](#blend-object)
     - [Blender Object](#blender-object)
     - [Loop Object](#loop-object)
+    - [Animation Object](#animation-object)
+    - [UV Ranges Object](#uv-ranges-object)
 - [Full Example](#full-example)
 
 # Structure
@@ -271,6 +274,24 @@ The basic structure of a fabricskyboxes skybox file may look something like this
   [
     /* single sprite texture for first frame (string) */
     // ...
+  ],
+  "animations": [ // animation objects for animation (multi-texture)
+    {
+      "texture": "", // animation sprite sheet texture (string)
+      "uvRanges": { // uv ranges for animation (uv-ranges-object)
+        "minU": 0.25,
+        "minV": 0.25,
+        "maxU": 0.50,
+        "maxV": 0.50
+      },
+      "gridColumns": 32, // number of columns in sprite sheet
+      "gridRows": 1, // number of rows in sprite sheet
+      "duration": 40, // duration of each sprite in milliseconds
+      "frameDuration": { // map of frame duration in milliseconds
+        "1": 20,
+        "5": 10
+      }
+    }
   ]
 }
 ```
@@ -373,6 +394,14 @@ Only the `single-sprite-animated-square-textured` skybox type uses these fields
 |        Name         |                 Datatype                  |                     Description                      |      Required      | Default value |
 |:-------------------:|:-----------------------------------------:|:----------------------------------------------------:|:------------------:|:-------------:|
 | `animationTextures` | Array of [Namespaced Ids](#namespaced-id) | Specifies a list of locations to textures to be used | :white_check_mark: |       -       |
+
+### Multi Texture Skybox
+
+Only the `multi-texture` skybox type uses these fields
+
+|     Name     |                    Datatype                     |                   Description                    | Required | Default value |
+|:------------:|:-----------------------------------------------:|:------------------------------------------------:|:--------:|:-------------:|
+| `animations` | Array of [Animation objects](#animation-object) | Specifies a list of animation objects to be used |   :x:    |       -       |
 
 ## Data types
 
@@ -681,6 +710,32 @@ Does not contain any fields.
 ]
 ```
 
+### Map Object
+
+Represents an object consisting of key-value pairs.
+
+**Specification**
+
+This object does not have specific predefined fields. It's a flexible structure that can hold various types of keys and values.
+
+**Examples**
+
+Example 1: Map with integer keys and integer values
+```json
+{
+  "100": 0,
+  "2000": 512
+}
+```
+Example 2: Map with [Namespaced Ids](#namespaced-id) as keys and boolean values
+```json
+{
+  "minecraft:the_nether": false,
+  "minecraft:overworld": true
+}
+```
+
+
 ### Rotation Object
 
 Specifies static and axis rotation for a skybox.
@@ -878,6 +933,66 @@ Specifies the loop condition.
       "max": 21
     }
   ]
+}
+```
+
+### Animation Object
+
+Specifies an animation object.
+
+**Specification**
+
+|      Name       |                  Datatype                   |                                  Description                                  |      Required      | Default Value |
+|:---------------:|:-------------------------------------------:|:-----------------------------------------------------------------------------:|:------------------:|:-------------:|
+|    `texture`    |       [Namespaced Id](#namespaced-id)       | Specifies the location of the texture to be used when rendering the animation | :white_check_mark: |       -       |
+|   `uvRanges`    |    [UV Ranges Object](#uv-ranges-object)    |          Specifies the location in UV ranges to render the animation          | :white_check_mark: |       -       |
+|  `gridColumns`  |                   Integer                   |           Specifies the amount of columns the animation texture has           | :white_check_mark: |       -       |
+|   `gridRows`    |                   Integer                   |            Specifies the amount of rows the animation texture has             | :white_check_mark: |       -       |
+|   `duration`    |                   Integer                   |    Specifies the default duration of each animation frame in milliseconds     | :white_check_mark: |       -       |
+| `frameDuration` | [Map Object](#map-object)<Integer, Integer> |              Specifies the specific duration per animation frame              |        :x:         |       -       |
+
+**Example**
+
+```json
+{
+  "texture": "fabricskyboxes:/sky/anim_texture.png",
+  "uvRanges": {
+    "minU": 0.25,
+    "minV": 0.25,
+    "maxU": 0.50,
+    "maxV": 0.50
+  },
+  "gridColumns": 32,
+  "gridRows": 1,
+  "duration": 40,
+  "frameDuration": {
+    "1": 20,
+    "5": 10
+  }
+}
+```
+
+### UV Ranges Object
+
+Specifies a UV range object for defining texture coordinates.
+
+**Specification**
+
+|  Name  |   Data Type    |            Description             |      Required      | Default Value |
+|:------:|:--------------:|:----------------------------------:|:------------------:|:-------------:|
+| `minU` | Floating Point | Specifies the minimum U coordinate | :white_check_mark: |       -       |
+| `minV` | Floating Point | Specifies the minimum V coordinate | :white_check_mark: |       -       |
+| `maxU` | Floating Point | Specifies the maximum U coordinate | :white_check_mark: |       -       |
+| `maxV` | Floating Point | Specifies the maximum V coordinate | :white_check_mark: |       -       |
+
+**Example**
+
+```json
+{
+  "minU": 0.25,
+  "minV": 0.25,
+  "maxU": 0.50,
+  "maxV": 0.50
 }
 ```
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -42,7 +42,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndWor
     private final Predicate<? super Skybox> renderPredicate = (skybox) -> !this.activeSkyboxes.contains(skybox) && skybox.isActive();
     private Skybox currentSkybox = null;
     private boolean enabled = true;
-    private float totalAlpha = 0f;
 
     public static AbstractSkybox parseSkyboxJson(Identifier id, JsonObjectWrapper objectWrapper) {
         AbstractSkybox skybox;
@@ -128,11 +127,6 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndWor
     }
 
     @Internal
-    public float getTotalAlpha() {
-        return this.totalAlpha;
-    }
-
-    @Internal
     public void renderSkyboxes(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog) {
         this.activeSkyboxes.forEach(skybox -> {
             this.currentSkybox = skybox;
@@ -164,11 +158,9 @@ public class SkyboxManager implements FabricSkyBoxesApi, ClientTickEvents.EndWor
 
     @Override
     public void onEndTick(ClientWorld client) {
-        this.totalAlpha = (float) StreamSupport
+        StreamSupport
                 .stream(Iterables.concat(this.skyboxMap.values(), this.permanentSkyboxMap.values()).spliterator(), false)
-                .filter(FSBSkybox.class::isInstance)
-                .map(FSBSkybox.class::cast)
-                .mapToDouble(FSBSkybox::updateAlpha).sum();
+                .forEach(skybox -> skybox.tick(client));
         this.activeSkyboxes.removeIf(skybox -> !skybox.isActive());
         // Add the skyboxes to a activeSkyboxes container so that they can be ordered
         this.skyboxMap.values().stream().filter(this.renderPredicate).forEach(this.activeSkyboxes::add);

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/SkyboxManager.java
@@ -5,7 +5,6 @@ import com.google.common.collect.Iterables;
 import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
 import io.github.amerebagatelle.fabricskyboxes.api.FabricSkyBoxesApi;
-import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.FSBSkybox;
 import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.Skybox;
 import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
 import io.github.amerebagatelle.fabricskyboxes.skyboxes.AbstractSkybox;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/api/skyboxes/Skybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/api/skyboxes/Skybox.java
@@ -3,6 +3,7 @@ package io.github.amerebagatelle.fabricskyboxes.api.skyboxes;
 import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
 import org.joml.Matrix4f;
 
 public interface Skybox {
@@ -20,6 +21,7 @@ public interface Skybox {
     /**
      * The main render method for a skybox.
      * Override this if you are creating a skybox from this one.
+     * This will be process if {@link Skybox#isActive()}
      *
      * @param worldRendererAccess Access to the worldRenderer as skyboxes often require it.
      * @param matrices            The current MatrixStack.
@@ -28,6 +30,16 @@ public interface Skybox {
      * @param thickFog            Is using thick fog.
      */
     void render(WorldRendererAccess worldRendererAccess, MatrixStack matrices, Matrix4f matrix4f, float tickDelta, Camera camera, boolean thickFog);
+
+
+    /**
+     * The main thread for a skybox
+     * Override this if you need to process conditions for the skybox.
+     * This will be process regardless the state of {@link Skybox#isActive()}
+     *
+     * @param clientWorld The client's world
+     */
+    void tick(ClientWorld clientWorld);
 
     /**
      * Gets the state of the skybox.

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/AbstractSkybox.java
@@ -55,6 +55,11 @@ public abstract class AbstractSkybox implements FSBSkybox {
         this.decorations = decorations;
     }
 
+    @Override
+    public void tick(ClientWorld clientWorld) {
+        this.updateAlpha();
+    }
+
     /**
      * Calculates the alpha value for the current time and conditions and returns it.
      *

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
@@ -6,10 +6,7 @@ import com.google.common.collect.ImmutableBiMap;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Lifecycle;
 import io.github.amerebagatelle.fabricskyboxes.FabricSkyBoxesClient;
-import io.github.amerebagatelle.fabricskyboxes.skyboxes.textured.AnimatedSquareTexturedSkybox;
-import io.github.amerebagatelle.fabricskyboxes.skyboxes.textured.SingleSpriteAnimatedSquareTexturedSkybox;
-import io.github.amerebagatelle.fabricskyboxes.skyboxes.textured.SingleSpriteSquareTexturedSkybox;
-import io.github.amerebagatelle.fabricskyboxes.skyboxes.textured.SquareTexturedSkybox;
+import io.github.amerebagatelle.fabricskyboxes.skyboxes.textured.*;
 import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
@@ -31,6 +28,7 @@ public class SkyboxType<T extends AbstractSkybox> {
     public static final SkyboxType<SingleSpriteSquareTexturedSkybox> SINGLE_SPRITE_SQUARE_TEXTURED_SKYBOX;
     public static final SkyboxType<AnimatedSquareTexturedSkybox> ANIMATED_SQUARE_TEXTURED_SKYBOX;
     public static final SkyboxType<SingleSpriteAnimatedSquareTexturedSkybox> SINGLE_SPRITE_ANIMATED_SQUARE_TEXTURED_SKYBOX;
+    public static final SkyboxType<SomeNewTypeSkybox> SOME_NEW_TYPE_SKYBOX;
     public static final Codec<Identifier> SKYBOX_ID_CODEC;
 
     static {
@@ -42,6 +40,7 @@ public class SkyboxType<T extends AbstractSkybox> {
         SINGLE_SPRITE_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(SingleSpriteSquareTexturedSkybox.class, "single-sprite-square-textured").add(2, SingleSpriteSquareTexturedSkybox.CODEC).build());
         ANIMATED_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(AnimatedSquareTexturedSkybox.class, "animated-square-textured").add(2, AnimatedSquareTexturedSkybox.CODEC).build());
         SINGLE_SPRITE_ANIMATED_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(SingleSpriteAnimatedSquareTexturedSkybox.class, "single-sprite-animated-square-textured").add(2, SingleSpriteAnimatedSquareTexturedSkybox.CODEC).build());
+        SOME_NEW_TYPE_SKYBOX = register(SkyboxType.Builder.create(SomeNewTypeSkybox.class, "some-new-type").add(2, SomeNewTypeSkybox.CODEC).build());
         SKYBOX_ID_CODEC = Codec.STRING.xmap((s) -> {
             if (!s.contains(":")) {
                 return new Identifier(FabricSkyBoxesClient.MODID, s.replace('-', '_'));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/SkyboxType.java
@@ -28,7 +28,7 @@ public class SkyboxType<T extends AbstractSkybox> {
     public static final SkyboxType<SingleSpriteSquareTexturedSkybox> SINGLE_SPRITE_SQUARE_TEXTURED_SKYBOX;
     public static final SkyboxType<AnimatedSquareTexturedSkybox> ANIMATED_SQUARE_TEXTURED_SKYBOX;
     public static final SkyboxType<SingleSpriteAnimatedSquareTexturedSkybox> SINGLE_SPRITE_ANIMATED_SQUARE_TEXTURED_SKYBOX;
-    public static final SkyboxType<SomeNewTypeSkybox> SOME_NEW_TYPE_SKYBOX;
+    public static final SkyboxType<MultiTextureSkybox> MULTI_TEXTURE_SKYBOX;
     public static final Codec<Identifier> SKYBOX_ID_CODEC;
 
     static {
@@ -40,7 +40,7 @@ public class SkyboxType<T extends AbstractSkybox> {
         SINGLE_SPRITE_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(SingleSpriteSquareTexturedSkybox.class, "single-sprite-square-textured").add(2, SingleSpriteSquareTexturedSkybox.CODEC).build());
         ANIMATED_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(AnimatedSquareTexturedSkybox.class, "animated-square-textured").add(2, AnimatedSquareTexturedSkybox.CODEC).build());
         SINGLE_SPRITE_ANIMATED_SQUARE_TEXTURED_SKYBOX = register(SkyboxType.Builder.create(SingleSpriteAnimatedSquareTexturedSkybox.class, "single-sprite-animated-square-textured").add(2, SingleSpriteAnimatedSquareTexturedSkybox.CODEC).build());
-        SOME_NEW_TYPE_SKYBOX = register(SkyboxType.Builder.create(SomeNewTypeSkybox.class, "some-new-type").add(2, SomeNewTypeSkybox.CODEC).build());
+        MULTI_TEXTURE_SKYBOX = register(SkyboxType.Builder.create(MultiTextureSkybox.class, "multi-texture").add(2, MultiTextureSkybox.CODEC).build());
         SKYBOX_ID_CODEC = Codec.STRING.xmap((s) -> {
             if (!s.contains(":")) {
                 return new Identifier(FabricSkyBoxesClient.MODID, s.replace('-', '_'));

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/MultiTextureSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/MultiTextureSkybox.java
@@ -10,7 +10,6 @@ import io.github.amerebagatelle.fabricskyboxes.util.Utils;
 import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.RotationAxis;
 import org.joml.Matrix4f;
@@ -85,8 +84,9 @@ public class MultiTextureSkybox extends TexturedSkybox {
 
             // animations
             for (Animation animation : this.animations) {
+                animation.tick();
                 UVRange intersect = Utils.findUVIntersection(faceUVRange, animation.getUvRanges()); // todo: cache this intersections so we don't waste gpu cycles
-                if (intersect != null && animation.getCurrentFrame() != null && animation.getNextFrame() != null) {
+                if (intersect != null && animation.getCurrentFrame() != null) {
                     UVRange intersectionOnCurrentTexture = Utils.mapUVRanges(faceUVRange, this.quad, intersect);
                     UVRange intersectionOnCurrentFrame = Utils.mapUVRanges(animation.getUvRanges(), animation.getCurrentFrame(), intersect);
 
@@ -103,14 +103,6 @@ public class MultiTextureSkybox extends TexturedSkybox {
             matrices.pop();
         }
         BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
-    }
-
-    @Override
-    public void tick(ClientWorld clientWorld) {
-        super.tick(clientWorld); // Don't remove :)
-        for (Animation animation : this.animations) {
-            animation.tick();
-        }
     }
 
     public List<Animation> getAnimations() {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/MultiTextureSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/MultiTextureSkybox.java
@@ -18,21 +18,21 @@ import org.joml.Matrix4f;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SomeNewTypeSkybox extends TexturedSkybox {
-    public static Codec<SomeNewTypeSkybox> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+public class MultiTextureSkybox extends TexturedSkybox {
+    public static Codec<MultiTextureSkybox> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Properties.CODEC.fieldOf("properties").forGetter(AbstractSkybox::getProperties),
             Conditions.CODEC.optionalFieldOf("conditions", Conditions.DEFAULT).forGetter(AbstractSkybox::getConditions),
             Decorations.CODEC.optionalFieldOf("decorations", Decorations.DEFAULT).forGetter(AbstractSkybox::getDecorations),
             Blend.CODEC.optionalFieldOf("blend", Blend.DEFAULT).forGetter(TexturedSkybox::getBlend),
-            Animation.CODEC.listOf().optionalFieldOf("animations", new ArrayList<>()).forGetter(SomeNewTypeSkybox::getAnimations)
-    ).apply(instance, SomeNewTypeSkybox::new));
+            Animation.CODEC.listOf().optionalFieldOf("animations", new ArrayList<>()).forGetter(MultiTextureSkybox::getAnimations)
+    ).apply(instance, MultiTextureSkybox::new));
     protected final List<Animation> animations;
     private final UVRanges uvRanges;
 
     private final float quadSize = 100F;
     private final UVRange quad = new UVRange(-this.quadSize, -this.quadSize, this.quadSize, this.quadSize);
 
-    public SomeNewTypeSkybox(Properties properties, Conditions conditions, Decorations decorations, Blend blend, List<Animation> animations) {
+    public MultiTextureSkybox(Properties properties, Conditions conditions, Decorations decorations, Blend blend, List<Animation> animations) {
         super(properties, conditions, decorations, blend);
         this.animations = animations;
         this.uvRanges = Util.make(() -> new UVRanges(
@@ -47,7 +47,7 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
 
     @Override
     public SkyboxType<? extends AbstractSkybox> getType() {
-        return SkyboxType.SOME_NEW_TYPE_SKYBOX;
+        return SkyboxType.MULTI_TEXTURE_SKYBOX;
     }
 
     @Override

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SingleSpriteSquareTexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SingleSpriteSquareTexturedSkybox.java
@@ -9,7 +9,6 @@ import io.github.amerebagatelle.fabricskyboxes.skyboxes.SkyboxType;
 import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.util.Util;
 import net.minecraft.util.math.RotationAxis;
 import org.joml.Matrix4f;
 
@@ -51,7 +50,7 @@ public class SingleSpriteSquareTexturedSkybox extends TexturedSkybox {
     public void renderSkybox(WorldRendererAccess worldRendererAccess, MatrixStack matrices, float tickDelta, Camera camera, boolean thickFog) {
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder bufferBuilder = tessellator.getBuffer();
-        bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+        bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
         RenderSystem.setShaderTexture(0, texture.getTextureId());
         for (int i = 0; i < 6; ++i) {
             // 0 = bottom
@@ -79,10 +78,10 @@ public class SingleSpriteSquareTexturedSkybox extends TexturedSkybox {
             }
 
             Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(tex.getMinU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(tex.getMinU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(tex.getMaxU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(tex.getMaxU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
+            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(tex.getMinU(), tex.getMinV()).next();
+            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(tex.getMinU(), tex.getMaxV()).next();
+            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(tex.getMaxU(), tex.getMaxV()).next();
+            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(tex.getMaxU(), tex.getMinV()).next();
             matrices.pop();
         }
         BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
@@ -10,6 +10,7 @@ import io.github.amerebagatelle.fabricskyboxes.util.Utils;
 import io.github.amerebagatelle.fabricskyboxes.util.object.*;
 import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.RotationAxis;
 import org.joml.Matrix4f;
@@ -23,27 +24,24 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
             Conditions.CODEC.optionalFieldOf("conditions", Conditions.DEFAULT).forGetter(AbstractSkybox::getConditions),
             Decorations.CODEC.optionalFieldOf("decorations", Decorations.DEFAULT).forGetter(AbstractSkybox::getDecorations),
             Blend.CODEC.optionalFieldOf("blend", Blend.DEFAULT).forGetter(TexturedSkybox::getBlend),
-            Texture.CODEC.fieldOf("texture").forGetter(SomeNewTypeSkybox::getTexture),
             Animation.CODEC.listOf().optionalFieldOf("animations", new ArrayList<>()).forGetter(SomeNewTypeSkybox::getAnimations)
     ).apply(instance, SomeNewTypeSkybox::new));
-    protected final Texture texture;
     protected final List<Animation> animations;
-    private final Textures textures;
-    
-    private final float quadSize = 100F;
-    private final UVRanges quad = new UVRanges(-this.quadSize, -this.quadSize, this.quadSize, this.quadSize);
+    private final UVRanges uvRanges;
 
-    public SomeNewTypeSkybox(Properties properties, Conditions conditions, Decorations decorations, Blend blend, Texture texture, List<Animation> animations) {
+    private final float quadSize = 100F;
+    private final UVRange quad = new UVRange(-this.quadSize, -this.quadSize, this.quadSize, this.quadSize);
+
+    public SomeNewTypeSkybox(Properties properties, Conditions conditions, Decorations decorations, Blend blend, List<Animation> animations) {
         super(properties, conditions, decorations, blend);
-        this.texture = texture;
         this.animations = animations;
-        this.textures = Util.make(() -> new Textures(
-                texture.withUV(1.0F / 3.0F, 1.0F / 2.0F, 2.0F / 3.0F, 1),
-                texture.withUV(2.0F / 3.0F, 0, 1, 1.0F / 2.0F),
-                texture.withUV(2.0F / 3.0F, 1.0F / 2.0F, 1, 1),
-                texture.withUV(0, 1.0F / 2.0F, 1.0F / 3.0F, 1),
-                texture.withUV(1.0F / 3.0F, 0, 2.0F / 3.0F, 1.0F / 2.0F),
-                texture.withUV(0, 0, 1.0F / 3.0F, 1.0F / 2.0F)
+        this.uvRanges = Util.make(() -> new UVRanges(
+                new UVRange(1.0F / 3.0F, 1.0F / 2.0F, 2.0F / 3.0F, 1),
+                new UVRange(2.0F / 3.0F, 0, 1, 1.0F / 2.0F),
+                new UVRange(2.0F / 3.0F, 1.0F / 2.0F, 1, 1),
+                new UVRange(0, 1.0F / 2.0F, 1.0F / 3.0F, 1),
+                new UVRange(1.0F / 3.0F, 0, 2.0F / 3.0F, 1.0F / 2.0F),
+                new UVRange(0, 0, 1.0F / 3.0F, 1.0F / 2.0F)
         ));
     }
 
@@ -64,10 +62,8 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
             // 3 = top
             // 4 = east
             // 5 = west
-            Texture tex = this.textures.byId(i);
+            UVRange faceUVRange = this.uvRanges.byId(i);
             matrices.push();
-
-            RenderSystem.setShaderTexture(0, tex.getTextureId());
 
             if (i == 1) {
                 matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
@@ -85,21 +81,13 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
             }
 
             Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-            bufferBuilder.vertex(matrix4f, -this.quadSize, -this.quadSize, -this.quadSize).texture(tex.getMinU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, -this.quadSize, -this.quadSize, this.quadSize).texture(tex.getMinU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, this.quadSize, -this.quadSize, this.quadSize).texture(tex.getMaxU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, this.quadSize, -this.quadSize, -this.quadSize).texture(tex.getMaxU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
-            tessellator.draw();
 
             // animations
-            for (Animation animation : animations) {
-                animation.tick(camera.getFocusedEntity().getWorld().getTimeOfDay()); // todo: we should have tick method for Skyboxes
-
-                UVRanges intersect = Utils.calculateUVIntersection(tex, animation.getUvRanges()); // todo: cache this intersections so we don't waste gpu cycles
+            for (Animation animation : this.animations) {
+                UVRange intersect = Utils.calculateUVIntersection(faceUVRange, animation.getUvRanges()); // todo: cache this intersections so we don't waste gpu cycles
                 if (intersect != null) {
-                    UVRanges intersectionOnCurrentTexture = Utils.mapUVRanges(tex, this.quad, intersect);
-                    UVRanges intersectionOnCurrentFrame = Utils.mapUVRanges(animation.getUvRanges(), animation.getCurrentFrame(), intersect);
+                    UVRange intersectionOnCurrentTexture = Utils.mapUVRanges(faceUVRange, this.quad, intersect);
+                    UVRange intersectionOnCurrentFrame = Utils.mapUVRanges(animation.getUvRanges(), animation.getCurrentFrame(), intersect);
 
                     // Render the quad at the calculated position
                     RenderSystem.setShaderTexture(0, animation.getTexture().getTextureId());
@@ -116,8 +104,12 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
         }
     }
 
-    public Texture getTexture() {
-        return this.texture;
+    @Override
+    public void tick(ClientWorld clientWorld) {
+        super.tick(clientWorld); // Don't remove :)
+        for (Animation animation : this.animations) {
+            animation.tick(clientWorld.getTimeOfDay());
+        }
     }
 
     public List<Animation> getAnimations() {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
@@ -52,12 +52,10 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
 
     @Override
     public void renderSkybox(WorldRendererAccess worldRendererAccess, MatrixStack matrices, float tickDelta, Camera camera, boolean thickFog) {
-        RenderSystem.setShader(GameRenderer::getPositionTexColorProgram);
-
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder bufferBuilder = tessellator.getBuffer();
 
-        bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+        bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
         for (int i = 0; i < 6; ++i) {
             // 0 = bottom
             // 1 = north
@@ -87,54 +85,31 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
 
             // animations
             for (Animation animation : this.animations) {
-                UVRange intersect = Utils.calculateUVIntersection(faceUVRange, animation.getUvRanges()); // todo: cache this intersections so we don't waste gpu cycles
+                UVRange intersect = Utils.findUVIntersection(faceUVRange, animation.getUvRanges()); // todo: cache this intersections so we don't waste gpu cycles
                 if (intersect != null && animation.getCurrentFrame() != null && animation.getNextFrame() != null) {
                     UVRange intersectionOnCurrentTexture = Utils.mapUVRanges(faceUVRange, this.quad, intersect);
                     UVRange intersectionOnCurrentFrame = Utils.mapUVRanges(animation.getUvRanges(), animation.getCurrentFrame(), intersect);
-                    UVRange intersectionOnNextFrame = Utils.mapUVRanges(animation.getUvRanges(), animation.getNextFrame(), intersect);
 
                     // Render the quad at the calculated position
                     RenderSystem.setShaderTexture(0, animation.getTexture().getTextureId());
 
-                    
-                    float alpha = this.alpha;
-                    float red = 1f, green = 1f, blue = 1f;
-
-                    if (animation.isInterpolate()) {
-                        red = red * animation.interpolationFactor();
-                        green = green * animation.interpolationFactor();
-                        blue = blue * animation.interpolationFactor();
-                        alpha = this.alpha * animation.interpolationFactor();
-                    }
-
-                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -this.quadSize, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMinV()).color(red, green, blue, alpha).next();
-                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -this.quadSize, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMaxV()).color(red, green, blue, alpha).next();
-                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -this.quadSize, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMaxV()).color(red, green, blue, alpha).next();
-                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -this.quadSize, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMinV()).color(red, green, blue, alpha).next();
-
-                    if (animation.isInterpolate()) {
-                        float invRed = 1 - red;
-                        float invGreen = 1 - green;
-                        float invBlue = 1 - blue;
-                        float invAlpha = 1 - alpha;
-                        bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -this.quadSize, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnNextFrame.getMinU(), intersectionOnNextFrame.getMinV()).color(invRed, invGreen, invBlue, invAlpha).next();
-                        bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -this.quadSize, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnNextFrame.getMinU(), intersectionOnNextFrame.getMaxV()).color(invRed, invGreen, invBlue, invAlpha).next();
-                        bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -this.quadSize, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnNextFrame.getMaxU(), intersectionOnNextFrame.getMaxV()).color(invRed, invGreen, invBlue, invAlpha).next();
-                        bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -this.quadSize, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnNextFrame.getMaxU(), intersectionOnNextFrame.getMinV()).color(invRed, invGreen, invBlue, invAlpha).next();
-                    }
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -this.quadSize, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMinV()).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -this.quadSize, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMaxV()).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -this.quadSize, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMaxV()).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -this.quadSize, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMinV()).next();
                 }
             }
 
             matrices.pop();
         }
-        tessellator.draw();
+        BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
     }
 
     @Override
     public void tick(ClientWorld clientWorld) {
         super.tick(clientWorld); // Don't remove :)
         for (Animation animation : this.animations) {
-            animation.tick(clientWorld.getTimeOfDay());
+            animation.tick();
         }
     }
 

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
@@ -96,24 +96,43 @@ public class SomeNewTypeSkybox extends TexturedSkybox {
 
                 UVRanges intersect = this.calculateIntersectionRange(tex, animation.getUvRanges());
                 if (intersect != null) {
-                    float u1 = -QUAD_SIZE + (intersect.getMinU() - tex.getMinU()) / (tex.getMaxU() - tex.getMinU()) * (QUAD_SIZE + QUAD_SIZE);
-                    float v1 = QUAD_SIZE + (intersect.getMinV() - tex.getMinV()) / (tex.getMaxV() - tex.getMinV()) * (-QUAD_SIZE - QUAD_SIZE);
+                    //fixme:
+                    /*float u1 = -QUAD_SIZE + (intersect.getMinU() - tex.getMinU()) / (tex.getMaxU() - tex.getMinU()) * (QUAD_SIZE + QUAD_SIZE);
+                    float v1 = -QUAD_SIZE + (intersect.getMinV() - tex.getMinV()) / (tex.getMaxV() - tex.getMinV()) * (QUAD_SIZE + QUAD_SIZE);
                     float u2 = -QUAD_SIZE + (intersect.getMaxU() - tex.getMinU()) / (tex.getMaxU() - tex.getMinU()) * (QUAD_SIZE + QUAD_SIZE);
-                    float v2 = QUAD_SIZE + (intersect.getMaxV() - tex.getMinV()) / (tex.getMaxV() - tex.getMinV()) * (-QUAD_SIZE - QUAD_SIZE);
+                    float v2 = -QUAD_SIZE + (intersect.getMaxV() - tex.getMinV()) / (tex.getMaxV() - tex.getMinV()) * (QUAD_SIZE + QUAD_SIZE);*/
+
+
+                    UVRanges intersectionOnCurrentTexture = this.map(tex, new UVRanges(-100, -100, 100, 100), intersect);
+                    UVRanges intersectionOnCurrentFrame = this.map(animation.getUvRanges(), animation.getCurrentFrame(), intersect);
 
                     // Render the quad at the calculated position
+                    //matrices.push();
                     RenderSystem.setShaderTexture(0, animation.getTexture().getTextureId());
                     bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
-                    bufferBuilder.vertex(matrix4f, u1, -QUAD_SIZE, v2).texture(animation.getCurrentFrame().getMinU(), animation.getCurrentFrame().getMinV()).color(1f, 1f, 1f, alpha).next();
-                    bufferBuilder.vertex(matrix4f, u2, -QUAD_SIZE, v2).texture(animation.getCurrentFrame().getMinU(), animation.getCurrentFrame().getMaxV()).color(1f, 1f, 1f, alpha).next();
-                    bufferBuilder.vertex(matrix4f, u2, -QUAD_SIZE, v1).texture(animation.getCurrentFrame().getMaxU(), animation.getCurrentFrame().getMaxV()).color(1f, 1f, 1f, alpha).next();
-                    bufferBuilder.vertex(matrix4f, u1, -QUAD_SIZE, v1).texture(animation.getCurrentFrame().getMaxU(), animation.getCurrentFrame().getMinV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -QUAD_SIZE, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMinV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMinU(), -QUAD_SIZE, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMaxV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -QUAD_SIZE, intersectionOnCurrentTexture.getMaxV()).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMaxV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, intersectionOnCurrentTexture.getMaxU(), -QUAD_SIZE, intersectionOnCurrentTexture.getMinV()).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMinV()).color(1f, 1f, 1f, alpha).next();
+                    /*bufferBuilder.vertex(matrix4f, u1, -QUAD_SIZE, v1).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMinV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, u1, -QUAD_SIZE, v2).texture(intersectionOnCurrentFrame.getMinU(), intersectionOnCurrentFrame.getMaxV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, u2, -QUAD_SIZE, v2).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMaxV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, u2, -QUAD_SIZE, v1).texture(intersectionOnCurrentFrame.getMaxU(), intersectionOnCurrentFrame.getMinV()).color(1f, 1f, 1f, alpha).next();*/
                     tessellator.draw();
+                    //matrices.pop();
                 }
             }
 
             matrices.pop();
         }
+    }
+
+    public UVRanges map(UVRanges input, UVRanges output, UVRanges inputIntersection) {
+        float u1 = (inputIntersection.getMinU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
+        float u2 = (inputIntersection.getMaxU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
+        float v1 = (inputIntersection.getMinV() - input.getMinV()) / (input.getMaxV() - input.getMinV()) * (output.getMaxV() - output.getMinV()) + output.getMinV();
+        float v2 = (inputIntersection.getMaxV() - input.getMinV()) / (input.getMaxV() - input.getMinV()) * (output.getMaxV() - output.getMinV()) + output.getMinV();
+        return new UVRanges(u1, v1, u2, v2);
     }
 
     public UVRanges calculateIntersectionRange(UVRanges faceUvRange, UVRanges replacement) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SomeNewTypeSkybox.java
@@ -1,0 +1,140 @@
+package io.github.amerebagatelle.fabricskyboxes.skyboxes.textured;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.amerebagatelle.fabricskyboxes.mixin.skybox.WorldRendererAccess;
+import io.github.amerebagatelle.fabricskyboxes.skyboxes.AbstractSkybox;
+import io.github.amerebagatelle.fabricskyboxes.skyboxes.SkyboxType;
+import io.github.amerebagatelle.fabricskyboxes.util.object.*;
+import net.minecraft.client.render.*;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.RotationAxis;
+import org.joml.Matrix4f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SomeNewTypeSkybox extends TexturedSkybox {
+    public static Codec<SomeNewTypeSkybox> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Properties.CODEC.fieldOf("properties").forGetter(AbstractSkybox::getProperties),
+            Conditions.CODEC.optionalFieldOf("conditions", Conditions.DEFAULT).forGetter(AbstractSkybox::getConditions),
+            Decorations.CODEC.optionalFieldOf("decorations", Decorations.DEFAULT).forGetter(AbstractSkybox::getDecorations),
+            Blend.CODEC.optionalFieldOf("blend", Blend.DEFAULT).forGetter(TexturedSkybox::getBlend),
+            Texture.CODEC.fieldOf("texture").forGetter(SomeNewTypeSkybox::getTexture),
+            Animation.CODEC.listOf().optionalFieldOf("animations", new ArrayList<>()).forGetter(SomeNewTypeSkybox::getAnimations)
+    ).apply(instance, SomeNewTypeSkybox::new));
+    protected final Texture texture;
+    protected final List<Animation> animations;
+    private final Textures textures;
+
+    public SomeNewTypeSkybox(Properties properties, Conditions conditions, Decorations decorations, Blend blend, Texture texture, List<Animation> animations) {
+        super(properties, conditions, decorations, blend);
+        this.texture = texture;
+        this.animations = animations;
+        this.textures = Util.make(() -> new Textures(
+                texture.withUV(1.0F / 3.0F, 1.0F / 2.0F, 2.0F / 3.0F, 1),
+                texture.withUV(2.0F / 3.0F, 0, 1, 1.0F / 2.0F),
+                texture.withUV(2.0F / 3.0F, 1.0F / 2.0F, 1, 1),
+                texture.withUV(0, 1.0F / 2.0F, 1.0F / 3.0F, 1),
+                texture.withUV(1.0F / 3.0F, 0, 2.0F / 3.0F, 1.0F / 2.0F),
+                texture.withUV(0, 0, 1.0F / 3.0F, 1.0F / 2.0F)
+        ));
+    }
+
+    @Override
+    public SkyboxType<? extends AbstractSkybox> getType() {
+        return SkyboxType.SOME_NEW_TYPE_SKYBOX;
+    }
+
+    @Override
+    public void renderSkybox(WorldRendererAccess worldRendererAccess, MatrixStack matrices, float tickDelta, Camera camera, boolean thickFog) {
+        Tessellator tessellator = Tessellator.getInstance();
+        BufferBuilder bufferBuilder = tessellator.getBuffer();
+        
+        final float QUAD_SIZE = 100F;
+
+        for (int i = 0; i < 6; ++i) {
+            // 0 = bottom
+            // 1 = north
+            // 2 = south
+            // 3 = top
+            // 4 = east
+            // 5 = west
+            Texture tex = this.textures.byId(i);
+            matrices.push();
+
+            RenderSystem.setShaderTexture(0, tex.getTextureId());
+
+            if (i == 1) {
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(90.0F));
+            } else if (i == 2) {
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90.0F));
+                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180.0F));
+            } else if (i == 3) {
+                matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180.0F));
+            } else if (i == 4) {
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(90.0F));
+                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-90.0F));
+            } else if (i == 5) {
+                matrices.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(-90.0F));
+                matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(90.0F));
+            }
+
+            Matrix4f matrix4f = matrices.peek().getPositionMatrix();
+            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+            bufferBuilder.vertex(matrix4f, -QUAD_SIZE, -QUAD_SIZE, -QUAD_SIZE).texture(tex.getMinU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
+            bufferBuilder.vertex(matrix4f, -QUAD_SIZE, -QUAD_SIZE, QUAD_SIZE).texture(tex.getMinU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
+            bufferBuilder.vertex(matrix4f, QUAD_SIZE, -QUAD_SIZE, QUAD_SIZE).texture(tex.getMaxU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
+            bufferBuilder.vertex(matrix4f, QUAD_SIZE, -QUAD_SIZE, -QUAD_SIZE).texture(tex.getMaxU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
+            tessellator.draw();
+
+            // animations
+            for (Animation animation : animations) {
+                animation.tick(camera.getFocusedEntity().getWorld().getTimeOfDay()); // todo: we should have tick method for Skyboxes
+
+                UVRanges intersect = this.calculateIntersectionRange(tex, animation.getUvRanges());
+                if (intersect != null) {
+                    float u1 = -QUAD_SIZE + (intersect.getMinU() - tex.getMinU()) / (tex.getMaxU() - tex.getMinU()) * (QUAD_SIZE + QUAD_SIZE);
+                    float v1 = QUAD_SIZE + (intersect.getMinV() - tex.getMinV()) / (tex.getMaxV() - tex.getMinV()) * (-QUAD_SIZE - QUAD_SIZE);
+                    float u2 = -QUAD_SIZE + (intersect.getMaxU() - tex.getMinU()) / (tex.getMaxU() - tex.getMinU()) * (QUAD_SIZE + QUAD_SIZE);
+                    float v2 = QUAD_SIZE + (intersect.getMaxV() - tex.getMinV()) / (tex.getMaxV() - tex.getMinV()) * (-QUAD_SIZE - QUAD_SIZE);
+
+                    // Render the quad at the calculated position
+                    RenderSystem.setShaderTexture(0, animation.getTexture().getTextureId());
+                    bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+                    bufferBuilder.vertex(matrix4f, u1, -QUAD_SIZE, v2).texture(animation.getCurrentFrame().getMinU(), animation.getCurrentFrame().getMinV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, u2, -QUAD_SIZE, v2).texture(animation.getCurrentFrame().getMinU(), animation.getCurrentFrame().getMaxV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, u2, -QUAD_SIZE, v1).texture(animation.getCurrentFrame().getMaxU(), animation.getCurrentFrame().getMaxV()).color(1f, 1f, 1f, alpha).next();
+                    bufferBuilder.vertex(matrix4f, u1, -QUAD_SIZE, v1).texture(animation.getCurrentFrame().getMaxU(), animation.getCurrentFrame().getMinV()).color(1f, 1f, 1f, alpha).next();
+                    tessellator.draw();
+                }
+            }
+
+            matrices.pop();
+        }
+    }
+
+    public UVRanges calculateIntersectionRange(UVRanges faceUvRange, UVRanges replacement) {
+        float intersectionMinU = Math.max(faceUvRange.getMinU(), replacement.getMinU());
+        float intersectionMaxU = Math.min(faceUvRange.getMaxU(), replacement.getMaxU());
+        float intersectionMinV = Math.max(faceUvRange.getMinV(), replacement.getMinV());
+        float intersectionMaxV = Math.min(faceUvRange.getMaxV(), replacement.getMaxV());
+
+        if (intersectionMaxU >= intersectionMinU && intersectionMaxV >= intersectionMinV) {
+            return new UVRanges(intersectionMinU, intersectionMinV, intersectionMaxU, intersectionMaxV);
+        } else {
+            // No intersection
+            return null;
+        }
+    }
+
+    public Texture getTexture() {
+        return this.texture;
+    }
+
+    public List<Animation> getAnimations() {
+        return animations;
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SquareTexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SquareTexturedSkybox.java
@@ -67,10 +67,10 @@ public class SquareTexturedSkybox extends TexturedSkybox {
             }
 
             Matrix4f matrix4f = matrices.peek().getPositionMatrix();
-            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(tex.getMinU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(tex.getMinU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(tex.getMaxU(), tex.getMaxV()).color(1f, 1f, 1f, alpha).next();
-            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(tex.getMaxU(), tex.getMinV()).color(1f, 1f, 1f, alpha).next();
+            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, -100.0F).texture(tex.getMinU(), tex.getMinV()).next();
+            bufferBuilder.vertex(matrix4f, -100.0F, -100.0F, 100.0F).texture(tex.getMinU(), tex.getMaxV()).next();
+            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, 100.0F).texture(tex.getMaxU(), tex.getMaxV()).next();
+            bufferBuilder.vertex(matrix4f, 100.0F, -100.0F, -100.0F).texture(tex.getMaxU(), tex.getMinV()).next();
             matrices.pop();
             BufferRenderer.drawWithGlobalProgram(bufferBuilder.end());
         }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SquareTexturedSkybox.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/skyboxes/textured/SquareTexturedSkybox.java
@@ -48,7 +48,7 @@ public class SquareTexturedSkybox extends TexturedSkybox {
             // 5 = west
             Texture tex = this.textures.byId(i);
             RenderSystem.setShaderTexture(0, tex.getTextureId());
-            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);
+            bufferBuilder.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE);
             matrices.push();
 
             if (i == 1) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
@@ -10,6 +10,7 @@ import io.github.amerebagatelle.fabricskyboxes.util.object.MinMaxEntry;
 import io.github.amerebagatelle.fabricskyboxes.util.object.RGBA;
 import net.minecraft.client.world.ClientWorld;
 import io.github.amerebagatelle.fabricskyboxes.util.object.UVRanges;
+import io.github.amerebagatelle.fabricskyboxes.util.object.UVRange;
 import net.minecraft.util.math.MathHelper;
 
 import java.util.Comparator;
@@ -19,22 +20,22 @@ import java.util.function.Function;
 
 public class Utils {
 
-    public static UVRanges mapUVRanges(UVRanges input, UVRanges output, UVRanges inputIntersection) {
+    public static UVRange mapUVRanges(UVRange input, UVRange output, UVRange inputIntersection) {
         float u1 = (inputIntersection.getMinU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
         float u2 = (inputIntersection.getMaxU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
         float v1 = (inputIntersection.getMinV() - input.getMinV()) / (input.getMaxV() - input.getMinV()) * (output.getMaxV() - output.getMinV()) + output.getMinV();
         float v2 = (inputIntersection.getMaxV() - input.getMinV()) / (input.getMaxV() - input.getMinV()) * (output.getMaxV() - output.getMinV()) + output.getMinV();
-        return new UVRanges(u1, v1, u2, v2);
+        return new UVRange(u1, v1, u2, v2);
     }
 
-    public static UVRanges calculateUVIntersection(UVRanges first, UVRanges second) {
+    public static UVRange calculateUVIntersection(UVRange first, UVRange second) {
         float intersectionMinU = Math.max(first.getMinU(), second.getMinU());
         float intersectionMaxU = Math.min(first.getMaxU(), second.getMaxU());
         float intersectionMinV = Math.max(first.getMinV(), second.getMinV());
         float intersectionMaxV = Math.min(first.getMaxV(), second.getMaxV());
 
         if (intersectionMaxU >= intersectionMinU && intersectionMaxV >= intersectionMinV) {
-            return new UVRanges(intersectionMinU, intersectionMinV, intersectionMaxU, intersectionMaxV);
+            return new UVRange(intersectionMinU, intersectionMinV, intersectionMaxU, intersectionMaxV);
         } else {
             // No intersection
             return null;

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
@@ -8,9 +8,8 @@ import io.github.amerebagatelle.fabricskyboxes.api.skyboxes.Skybox;
 import io.github.amerebagatelle.fabricskyboxes.util.object.FogRGBA;
 import io.github.amerebagatelle.fabricskyboxes.util.object.MinMaxEntry;
 import io.github.amerebagatelle.fabricskyboxes.util.object.RGBA;
-import net.minecraft.client.world.ClientWorld;
-import io.github.amerebagatelle.fabricskyboxes.util.object.UVRanges;
 import io.github.amerebagatelle.fabricskyboxes.util.object.UVRange;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.MathHelper;
 
 import java.util.Comparator;
@@ -20,6 +19,14 @@ import java.util.function.Function;
 
 public class Utils {
 
+    /**
+     * Maps input intersection to output intersection, does so by taking in input and output UV ranges and then mapping the input intersection to the output intersection.
+     *
+     * @param input             The input UV range
+     * @param output            The output UV range
+     * @param inputIntersection The input intersection
+     * @return The output intersection
+     */
     public static UVRange mapUVRanges(UVRange input, UVRange output, UVRange inputIntersection) {
         float u1 = (inputIntersection.getMinU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
         float u2 = (inputIntersection.getMaxU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
@@ -28,7 +35,14 @@ public class Utils {
         return new UVRange(u1, v1, u2, v2);
     }
 
-    public static UVRange calculateUVIntersection(UVRange first, UVRange second) {
+    /**
+     * Finds the intersection between two UV ranges
+     *
+     * @param first  First UV range
+     * @param second Second UV range
+     * @return The intersection between the two UV ranges, if none is found, null is returned
+     */
+    public static UVRange findUVIntersection(UVRange first, UVRange second) {
         float intersectionMinU = Math.max(first.getMinU(), second.getMinU());
         float intersectionMaxU = Math.min(first.getMaxU(), second.getMaxU());
         float intersectionMinV = Math.max(first.getMinV(), second.getMinV());
@@ -78,6 +92,15 @@ public class Utils {
         return (int) (result >= 0 ? result : result + 24000);
     }
 
+    /**
+     * Calculates the rotation in degrees for skybox rotations
+     *
+     * @param rotationSpeed    Rotation speed
+     * @param timeShift        Time shift (by default 0, OptiFine starts at 18000)
+     * @param isSkyboxRotation Whether it is a skybox rotation or decoration rotation
+     * @param world            Client world
+     * @return Rotation in degrees
+     */
     public static double calculateRotation(double rotationSpeed, int timeShift, boolean isSkyboxRotation, ClientWorld world) {
         if (rotationSpeed != 0F) {
             long timeOfDay = world.getTimeOfDay() + timeShift;
@@ -145,7 +168,7 @@ public class Utils {
      * Calculates the cyclic distance (duration) between two time points on a cyclic timescale.
      *
      * @param startTime The first time point.
-     * @param endTime The second time point.
+     * @param endTime   The second time point.
      * @return The cyclic distance between the two time points.
      */
     public static int calculateCyclicTimeDistance(int startTime, int endTime) {

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/Utils.java
@@ -9,6 +9,7 @@ import io.github.amerebagatelle.fabricskyboxes.util.object.FogRGBA;
 import io.github.amerebagatelle.fabricskyboxes.util.object.MinMaxEntry;
 import io.github.amerebagatelle.fabricskyboxes.util.object.RGBA;
 import net.minecraft.client.world.ClientWorld;
+import io.github.amerebagatelle.fabricskyboxes.util.object.UVRanges;
 import net.minecraft.util.math.MathHelper;
 
 import java.util.Comparator;
@@ -17,6 +18,29 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public class Utils {
+
+    public static UVRanges mapUVRanges(UVRanges input, UVRanges output, UVRanges inputIntersection) {
+        float u1 = (inputIntersection.getMinU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
+        float u2 = (inputIntersection.getMaxU() - input.getMinU()) / (input.getMaxU() - input.getMinU()) * (output.getMaxU() - output.getMinU()) + output.getMinU();
+        float v1 = (inputIntersection.getMinV() - input.getMinV()) / (input.getMaxV() - input.getMinV()) * (output.getMaxV() - output.getMinV()) + output.getMinV();
+        float v2 = (inputIntersection.getMaxV() - input.getMinV()) / (input.getMaxV() - input.getMinV()) * (output.getMaxV() - output.getMinV()) + output.getMinV();
+        return new UVRanges(u1, v1, u2, v2);
+    }
+
+    public static UVRanges calculateUVIntersection(UVRanges first, UVRanges second) {
+        float intersectionMinU = Math.max(first.getMinU(), second.getMinU());
+        float intersectionMaxU = Math.min(first.getMaxU(), second.getMaxU());
+        float intersectionMinV = Math.max(first.getMinV(), second.getMinV());
+        float intersectionMaxV = Math.min(first.getMaxV(), second.getMaxV());
+
+        if (intersectionMaxU >= intersectionMinU && intersectionMaxV >= intersectionMinV) {
+            return new UVRanges(intersectionMinU, intersectionMinV, intersectionMaxU, intersectionMaxV);
+        } else {
+            // No intersection
+            return null;
+        }
+    }
+
     /**
      * @return Whether the value is within any of the minMaxEntries.
      */

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
@@ -27,6 +27,7 @@ public class Animation {
     private final Map<Integer, Integer> frameDuration;
 
     private UVRange currentFrame;
+    private UVRange nextFrame;
     private int index;
     private int currentTicks;
 
@@ -70,27 +71,39 @@ public class Animation {
 
     public void tick(long timeOfDay) {
         if (this.currentTicks == this.frameDuration.getOrDefault(this.index, this.duration)) {
-            if (this.index + 1 == this.gridRows * this.gridColumns) {
-                this.index = 0;
-            } else {
-                this.index++;
-            }
+            // Current Frame
+            this.index = (this.index + 1) % (this.gridRows * this.gridColumns);
+            this.currentFrame = this.calculateNextFrameUVRange(this.index);
 
-            // Calculate the UV ranges for the current frame
-            float frameWidth = 1.0F / this.gridColumns;
-            float frameHeight = 1.0F / this.gridRows;
-            float minU = (float) (this.index % this.gridColumns) * frameWidth;
-            float maxU = minU + frameWidth;
-            float minV = (float) (this.index / this.gridColumns) * frameHeight;
-            float maxV = minV + frameHeight;
-            this.currentFrame = new UVRange(minU, minV, maxU, maxV);
+            // Next Frame
+            int nextFrameIndex = (this.index + 1) % (this.gridRows * this.gridColumns);
+            this.nextFrame = this.calculateNextFrameUVRange(nextFrameIndex);
+
             this.currentTicks = 0;
             return;
         }
         this.currentTicks++;
     }
 
+    public UVRange getNextFrame() {
+        return this.nextFrame;
+    }
+
     public UVRange getCurrentFrame() {
         return currentFrame;
+    }
+
+    public float interpolationFactor() {
+        return (float) this.currentTicks / this.frameDuration.getOrDefault(this.index, this.duration);
+    }
+
+    private UVRange calculateNextFrameUVRange(int nextFrameIndex) {
+        float frameWidth = 1.0F / this.gridColumns;
+        float frameHeight = 1.0F / this.gridRows;
+        float minU = (float) (nextFrameIndex % this.gridColumns) * frameWidth;
+        float maxU = minU + frameWidth;
+        float minV = (float) (nextFrameIndex / this.gridColumns) * frameHeight;
+        float maxV = minV + frameHeight;
+        return new UVRange(minU, minV, maxU, maxV);
     }
 }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
@@ -69,7 +69,7 @@ public class Animation {
         return frameDuration;
     }
 
-    public void tick(long timeOfDay) {
+    public void tick() {
         if (this.currentTicks == this.frameDuration.getOrDefault(this.index, this.duration)) {
             // Current Frame
             this.index = (this.index + 1) % (this.gridRows * this.gridColumns);
@@ -100,9 +100,9 @@ public class Animation {
     private UVRange calculateNextFrameUVRange(int nextFrameIndex) {
         float frameWidth = 1.0F / this.gridColumns;
         float frameHeight = 1.0F / this.gridRows;
-        float minU = (float) (nextFrameIndex % this.gridColumns) * frameWidth;
+        float minU = (float) (nextFrameIndex / this.gridRows) * frameWidth;
         float maxU = minU + frameWidth;
-        float minV = (float) (nextFrameIndex / this.gridColumns) * frameHeight;
+        float minV = (float) (nextFrameIndex % this.gridRows) * frameHeight;
         float maxV = minV + frameHeight;
         return new UVRange(minU, minV, maxU, maxV);
     }

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
@@ -1,0 +1,94 @@
+package io.github.amerebagatelle.fabricskyboxes.util.object;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.github.amerebagatelle.fabricskyboxes.util.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Animation {
+    public static final Codec<Animation> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Texture.CODEC.fieldOf("texture").forGetter(Animation::getTexture),
+            UVRanges.CODEC.fieldOf("uvRanges").forGetter(Animation::getUvRanges),
+            Utils.getClampedInteger(1, Integer.MAX_VALUE).fieldOf("gridColumns").forGetter(Animation::getGridColumns),
+            Utils.getClampedInteger(1, Integer.MAX_VALUE).fieldOf("gridRows").forGetter(Animation::getGridRows),
+            Utils.getClampedInteger(1, Integer.MAX_VALUE).fieldOf("duration").forGetter(Animation::getDuration),
+            Codec.BOOL.optionalFieldOf("interpolate", true).forGetter(Animation::isInterpolate),
+            Codec.unboundedMap(Codec.INT, Codec.INT).optionalFieldOf("frameDuration", new HashMap<>()).forGetter(Animation::getFrameDuration)
+    ).apply(instance, Animation::new));
+
+    private final Texture texture;
+    private final UVRanges uvRanges;
+    private final int gridRows;
+    private final int gridColumns;
+    private final int duration;
+    private final boolean interpolate;
+    private final Map<Integer, Integer> frameDuration;
+
+    private UVRanges currentFrame;
+    private long nextTime;
+    private int index;
+
+    public Animation(Texture texture, UVRanges uvRanges, int gridColumns, int gridRows, int duration, boolean interpolate, Map<Integer, Integer> frameDuration) {
+        this.texture = texture;
+        this.uvRanges = uvRanges;
+        this.gridColumns = gridColumns;
+        this.gridRows = gridRows;
+        this.duration = duration;
+        this.interpolate = interpolate;
+        this.frameDuration = frameDuration;
+    }
+
+    public Texture getTexture() {
+        return texture;
+    }
+
+    public UVRanges getUvRanges() {
+        return uvRanges;
+    }
+
+    public int getGridColumns() {
+        return gridColumns;
+    }
+
+    public int getGridRows() {
+        return gridRows;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public boolean isInterpolate() {
+        return interpolate;
+    }
+
+    public Map<Integer, Integer> getFrameDuration() {
+        return frameDuration;
+    }
+
+    public void tick(long timeOfDay) {
+        if (timeOfDay >= this.nextTime) {
+            if (this.index + 1 == this.gridRows * this.gridColumns) {
+                this.index = 0;
+            } else {
+                this.index++;
+            }
+            this.nextTime = timeOfDay + this.frameDuration.getOrDefault(this.index, this.duration);
+
+            // Calculate the UV ranges for the current frame
+            float frameWidth = 1.0F / this.gridColumns;
+            float frameHeight = 1.0F / this.gridRows;
+            float minU = (float) (this.index % this.gridColumns) * frameWidth;
+            float maxU = minU + frameWidth;
+            float minV = (float) (this.index / this.gridColumns) * frameHeight;
+            float maxV = minV + frameHeight;
+            this.currentFrame = new UVRanges(minU, minV, maxU, maxV);
+        }
+    }
+
+    public UVRanges getCurrentFrame() {
+        return currentFrame;
+    }
+}

--- a/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
+++ b/src/main/java/io/github/amerebagatelle/fabricskyboxes/util/object/Animation.java
@@ -3,6 +3,7 @@ package io.github.amerebagatelle.fabricskyboxes.util.object;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.github.amerebagatelle.fabricskyboxes.util.Utils;
+import net.minecraft.util.Util;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,9 +28,8 @@ public class Animation {
     private final Map<Integer, Integer> frameDuration;
 
     private UVRange currentFrame;
-    private UVRange nextFrame;
     private int index;
-    private int currentTicks;
+    private long nextTime;
 
     public Animation(Texture texture, UVRange uvRange, int gridColumns, int gridRows, int duration, boolean interpolate, Map<Integer, Integer> frameDuration) {
         this.texture = texture;
@@ -70,33 +70,18 @@ public class Animation {
     }
 
     public void tick() {
-        if (this.currentTicks == this.frameDuration.getOrDefault(this.index, this.duration)) {
+        if (this.nextTime <= Util.getEpochTimeMs()) {
             // Current Frame
             this.index = (this.index + 1) % (this.gridRows * this.gridColumns);
             this.currentFrame = this.calculateNextFrameUVRange(this.index);
 
-            // Next Frame
-            int nextFrameIndex = (this.index + 1) % (this.gridRows * this.gridColumns);
-            this.nextFrame = this.calculateNextFrameUVRange(nextFrameIndex);
-
-            this.currentTicks = 0;
-            return;
+            this.nextTime = Util.getEpochTimeMs() + this.frameDuration.getOrDefault((this.index + 1) % (this.gridRows * this.gridColumns), this.duration);
         }
-        this.currentTicks++;
-    }
-
-    public UVRange getNextFrame() {
-        return this.nextFrame;
     }
 
     public UVRange getCurrentFrame() {
         return currentFrame;
     }
-
-    public float interpolationFactor() {
-        return (float) this.currentTicks / this.frameDuration.getOrDefault(this.index, this.duration);
-    }
-
     private UVRange calculateNextFrameUVRange(int nextFrameIndex) {
         float frameWidth = 1.0F / this.gridColumns;
         float frameHeight = 1.0F / this.gridRows;


### PR DESCRIPTION
# Refactor Summary

This PR introduces a new skybox type, enabling resource pack creators to specify multi-texture animations on various sections of the skybox using UV ranges.
# Motivation

The motivation behind these changes is to enhance our approach to animating skyboxes.
